### PR TITLE
Split index.tsx, add virtual layout, add drag and drop columns/rows

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -50,7 +50,7 @@ const App = () => {
                     <h3>Basic spreadsheet</h3>
                     <p>
                         It has all the features you'd expect from the spreadsheet: keyboard navigation, copy cells by
-                        dragging the small square, copy/paste from and to Excel and Google Sheets, resize columns and
+                        dragging the small square, copy/paste from and to Excel and Google Sheets, resize and reorder columns and
                         rows.
                     </p>
                 </div>
@@ -199,7 +199,7 @@ const App = () => {
                     <br />
                     <p>
                         You can also use <Emphased text="cellWidth" /> and <Emphased text="cellHeight" /> props to
-                        customize cell size. If you send single value {`cellWidth={200}`}, it will be applayed to all
+                        customize cell size. If you send single value {`cellWidth={200}`}, it will be applied to all
                         cells. If you send array of values {`cellWidth={[200, 80, 80]}`}, they will be applied in
                         respect to the index number.
                     </p>
@@ -222,7 +222,7 @@ const App = () => {
                     {/* onSelectionChanged */}
                     <h3>Selection</h3>
                     <p>
-                        You can send function to <Emphased text="onSelectionChanged" /> prop. It will be called on
+                        You can send a function to the <Emphased text="onSelectionChanged" /> prop. It will be called on
                         selection change with x1, y1, x2 and y2 arguments.
                     </p>
                 </div>
@@ -261,7 +261,7 @@ const App = () => {
                     {/* inputComponent */}
                     <h3>Custom input</h3>
                     <p>
-                        By default edit mode turns cell into text edit component. But you can send your custom input
+                        By default edit mode turns the cell into a text edit component. But you can send your custom input
                         component via <Emphased text="inputComponent" /> props. It will be called with{' '}
                         <Emphased text="x" />, <Emphased text="y" />, <Emphased text="inputProps" /> and{' '}
                         <Emphased text="commitEditingCell" /> arguments.

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -17,7 +17,6 @@ export const useClipboardCopy = (
         if (isEmptySelection(selection)) return;
 
         textArea.value = formatSelectionAsTSV(selection, editData);
-        textArea.select();
     }, [selection, editMode, editData, textAreaRef]);
 
     useLayoutEffect(() => {

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,0 +1,218 @@
+import { CellPropertyFunction, Change, ParsedChange, Rectangle } from './types';
+import { RefObject, useLayoutEffect, useEffect } from 'react';
+import { findApproxMaxEditDataIndex } from './props';
+import { normalizeSelection, isMaybeRowSelection, isMaybeColumnSelection, isEmptySelection } from './coordinate';
+
+export const useClipboardCopy = (
+    textAreaRef: RefObject<HTMLTextAreaElement>,
+    selection: Rectangle,
+    editMode: boolean,
+    editData: CellPropertyFunction<string>,
+) => {
+    useLayoutEffect(() => {
+        const {current: textArea} = textAreaRef;
+        if (!textArea) return;
+
+        if (editMode) return;
+        if (isEmptySelection(selection)) return;
+
+        textArea.value = formatSelectionAsTSV(selection, editData);
+        textArea.select();
+    }, [selection, editMode, editData, textAreaRef]);
+
+    useLayoutEffect(() => {
+        const {current: textArea} = textAreaRef;
+        if (!textArea) return;
+
+        const focus = () => {
+            textArea.focus({ preventScroll: true });
+            textArea.select();
+        };
+
+        if (editMode) return;
+        if (document.activeElement === textArea) return;
+
+        const activeTagName = (document as any).activeElement.tagName.toLowerCase();
+        if (
+            !(
+                (activeTagName === 'div' && (document as any).activeElement.contentEditable === 'true') ||
+                activeTagName === 'input' ||
+                activeTagName === 'textarea' ||
+                activeTagName === 'select'
+            )
+        ) {
+            focus();
+        }
+    });
+}
+
+export const useClipboardPaste = (
+    textAreaRef: RefObject<HTMLTextAreaElement>,
+    selection: Rectangle,
+    onSelectionChange?: (selection: Rectangle) => void,
+    onChange?: (changes: Array<Change>) => void,
+) => {
+    useEffect(() => {
+        const onPaste = (e: any) => {
+            const {current: textArea} = textAreaRef;
+            if (!textArea) return;
+
+            if (e.target !== textArea) return;
+            e.preventDefault();
+
+            const clipboardData = e.clipboardData || (window as any).clipboardData;
+            const types = clipboardData.types;
+
+            let parsed;
+            if (types.includes('text/html')) {
+                const pastedHtml = clipboardData.getData('text/html');
+                parsed = parsePastedHtml(selection, pastedHtml);
+            } else if (types.includes('text/plain')) {
+                const text = clipboardData.getData('text/plain');
+                parsed = parsePastedText(selection, text);
+            }
+            if (!parsed) return;
+
+            const {selection: s, changes} = parsed;
+            onChange?.(changes);
+            onSelectionChange?.(s);
+        };
+
+        window.document.addEventListener('paste', onPaste);
+        return () => {
+            window.document.removeEventListener('paste', onPaste);
+        };
+    }, [textAreaRef, selection]);
+}
+
+const formatTSV = (rows: string[][]) => rows.map(row => row.join('\t')).join('\n');
+
+const formatSelectionAsTSV = (
+    selection: Rectangle,
+    editData: CellPropertyFunction<string>,
+) => {
+    if (isEmptySelection(selection)) return '';
+
+    let [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
+    if (isMaybeRowSelection(selection)) {
+        const [cellX] = findApproxMaxEditDataIndex(editData);
+        minX = 0;
+        maxX = cellX;
+    }
+    if (isMaybeColumnSelection(selection)) {
+        const [, cellY] = findApproxMaxEditDataIndex(editData);
+        minY = 0;
+        maxY = cellY;
+    }
+
+    const rows: string[][] = [];
+
+    for (let y = minY; y <= maxY; y++) {
+        const row: string[] = [];
+
+        for (let x = minX; x <= maxX; x++) {
+            const value = editData(x, y);
+            if (value !== null && value !== undefined) {
+                row.push(value != null ? value : '');
+            }
+        }
+
+        rows.push(row);
+    }
+
+    return formatTSV(rows);
+}
+
+const findTable = (element: any): any => {
+    for (const child of element.children) {
+        if (child.nodeName === 'TABLE') {
+            return child;
+        }
+        const maybeTable = findTable(child);
+        if (maybeTable) {
+            return maybeTable;
+        }
+    }
+};
+
+const parsePastedHtml = (selection: Rectangle, html: string): ParsedChange | null => {
+    const div = document.createElement('div');
+    div.innerHTML = html.trim();
+
+    const [[minX, minY]] = normalizeSelection(selection);
+    let left = isMaybeRowSelection(selection) ? 0 : minX;
+    let top = isMaybeColumnSelection(selection) ? 0 : minY;
+
+    const changes = [];
+
+    const tableNode = findTable(div);
+    if (!tableNode) {
+        return null;
+    }
+
+    let right = left;
+    let bottom = top;
+
+    let y = top;
+    for (const tableChild of tableNode.children) {
+        if (tableChild.nodeName === 'TBODY') {
+            for (const tr of tableChild.children) {
+                let x = left;
+                if (tr.nodeName === 'TR') {
+                    for (const td of tr.children) {
+                        if (td.nodeName === 'TD') {
+                            let str: string = '';
+                            if (td.children.length !== 0 && td.children[0].nodeName === 'P') {
+                                const p = td.children[0];
+                                if (p.children.length !== 0 && p.children[0].nodeName === 'FONT') {
+                                    str = p.children[0].textContent.trim();
+                                } else {
+                                    str = p.textContent.trim();
+                                }
+                            } else {
+                                str = td.textContent.trim();
+                            }
+                            str = str.replaceAll('\n', '');
+                            str = str.replaceAll(/\s\s+/g, ' ');
+                            changes.push({ x, y, value: str });
+                            x++;
+                        }
+                    }
+                    y++;
+                }
+                right = Math.max(right, x);
+            }
+        }
+    }
+    bottom = y;
+
+    return {
+        selection: [[left, top], [right, bottom]],
+        changes,
+    };
+};
+
+const parsePastedText = (selection: Rectangle, text: string): ParsedChange => {
+    const [[minX, minY]] = normalizeSelection(selection);
+    let left = isMaybeRowSelection(selection) ? 0 : minX;
+    let top = isMaybeColumnSelection(selection) ? 0 : minY;
+
+    const rows = text.split(/\r?\n/);
+    let right = left;
+    let bottom = top + rows.length - 1;
+
+    const changes = [];
+    for (let y = 0; y < rows.length; y++) {
+        const cols = rows[y].split('\t');
+        right = Math.max(right, left + cols.length - 1);
+
+        for (let x = 0; x < cols.length; x++) {
+            changes.push({ x: left + x, y: top + y, value: cols[x] });
+        }
+    }
+
+    return {
+        selection: [[left, top], [right, bottom]],
+        changes,
+    };
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,7 +16,7 @@ export const MAX_XY: XY = [ MAX_SEARCHABLE_INDEX, MAX_SEARCHABLE_INDEX ];
 
 export const COLORS = {
     selectionBorder: '#1a66ff',
-    selectionBackground: '#e9f0fd',
+    selectionBackground: '#e8f0ff',
 
     gridLine: '#0000001f',
 
@@ -24,9 +24,10 @@ export const COLORS = {
     dropTarget: '#1a66ff',
     knobAreaBorder: '#707070',
 
-    headerBackground: '#f8f9fa',
+    headerBackground: '#f6f9fc',
     headerText: '#666666',
-    headerActive: '#e8eaed',
+    headerActive: '#e8f0ff',
+    headerActiveText: '#1a66ff',
 
     headerSelected: '#1a66ff',
     headerSelectedText: '#ffffff',
@@ -45,7 +46,7 @@ export const SIZES = {
 
 export const DEFAULT_CELL_STYLE: Required<Style> = {
     textAlign: 'left',
-    fontSize: 13,
+    fontSize: 12,
     marginRight: 5,
     marginLeft: 5,
     color: '#000',
@@ -57,7 +58,7 @@ export const DEFAULT_CELL_STYLE: Required<Style> = {
 
 export const DEFAULT_COLUMN_HEADER_STYLE: Required<Style> = {
     textAlign: 'center',
-    fontSize: 13,
+    fontSize: 12,
     marginRight: 5,
     marginLeft: 5,
     color: '#000',
@@ -65,6 +66,10 @@ export const DEFAULT_COLUMN_HEADER_STYLE: Required<Style> = {
     weight: '',
     fillColor: '',
     backgroundColor: '',
+};
+
+export const HEADER_ACTIVE_STYLE = {
+    color: COLORS.headerActiveText,
 };
 
 export const HEADER_SELECTED_STYLE = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,80 @@
+import { XY, Rectangle, Selection, Clickable, Direction, Style } from './types';
+
+export const INITIAL_MAX_SCROLL: XY = [ 2000, 1000 ];
+
+export const ORIGIN: XY = [ 0, 0 ];
+export const ONE_ONE: XY = [ 1, 1 ];
+
+export const NO_CELL: XY = [ -1, -1 ];
+export const NO_SELECTION: Rectangle = [NO_CELL, NO_CELL];
+export const NO_SELECTIONS: Selection[] = [];
+export const NO_CLICKABLES: Clickable[] = [];
+export const NO_STYLE = {};
+
+export const MAX_SEARCHABLE_INDEX = 65536;
+export const MAX_XY: XY = [ MAX_SEARCHABLE_INDEX, MAX_SEARCHABLE_INDEX ];
+
+export const COLORS = {
+    selectionBorder: '#1a66ff',
+    selectionBackground: '#e9f0fd',
+
+    gridLine: '#0000001f',
+
+    dragGhost: '#1a66ff30',
+    dropTarget: '#1a66ff',
+    knobAreaBorder: '#707070',
+
+    headerBackground: '#f8f9fa',
+    headerText: '#666666',
+    headerActive: '#e8eaed',
+
+    headerSelected: '#1a66ff',
+    headerSelectedText: '#ffffff',
+};
+
+export const SIZES = {
+    knobArea: 6,
+    headerWidth: 50,
+    headerHeight: 22,
+    minimumWidth: 50,
+    minimumHeight: 22,
+    resizeZone: 4,
+    scrollZone: 50,
+    scrollSpeed: 30,
+};
+
+export const DEFAULT_CELL_STYLE: Required<Style> = {
+    textAlign: 'left',
+    fontSize: 13,
+    marginRight: 5,
+    marginLeft: 5,
+    color: '#000',
+    fontFamily: 'sans-serif',
+    weight: '',
+    fillColor: '',
+    backgroundColor: '',
+};
+
+export const DEFAULT_COLUMN_HEADER_STYLE: Required<Style> = {
+    textAlign: 'center',
+    fontSize: 13,
+    marginRight: 5,
+    marginLeft: 5,
+    color: '#000',
+    fontFamily: 'sans-serif',
+    weight: '',
+    fillColor: '',
+    backgroundColor: '',
+};
+
+export const HEADER_SELECTED_STYLE = {
+    backgroundColor: COLORS.headerSelected,
+    color: COLORS.headerSelectedText,
+};
+
+export const ARROW_KEYS: Record<string, Direction> = {
+    'ArrowRight': 'right',
+    'ArrowLeft': 'left',
+    'ArrowUp': 'up',
+    'ArrowDown': 'down',
+};

--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -1,0 +1,81 @@
+import { XY, Rectangle } from './types';
+import { clamp } from './util';
+
+export const addXY = (a: XY, b: XY): XY => [a[0] + b[0], a[1] + b[1]];
+export const subXY = (a: XY, b: XY): XY => [a[0] - b[0], a[1] - b[1]];
+export const mulXY = (a: XY, b: XY): XY => [a[0] * b[0], a[1] * b[1]];
+export const maxXY = (a: XY, b: XY): XY => [Math.max(a[0], b[0]), Math.max(a[1], b[1])];
+export const minXY = (a: XY, b: XY): XY => [Math.min(a[0], b[0]), Math.min(a[1], b[1])];
+export const clampXY = (p: XY, min: XY, max: XY = [Infinity, Infinity]): XY => [clamp(p[0], min[0], max[0]), clamp(p[1], min[1], max[1])];
+
+export const getDirectionStep = (direction: string): XY => {
+    if (direction === 'left') return [-1, 0];
+    if (direction === 'right') return [1, 0];
+    if (direction === 'up') return [0, -1];
+    if (direction === 'down') return [0, 1];
+    return [0, 0];
+};
+
+export const isSameXY = (a: XY, b: XY) => a[0] === b[0] && a[1] === b[1];
+
+export const isSameSelection = (a: Rectangle, b: Rectangle) => {
+    const [a1, a2] = a;
+    const [b1, b2] = b;
+    return isSameXY(a1, b1) && isSameXY(a2, b2);
+};
+
+// Selection is infinite horizontally
+export const isMaybeRowSelection = (selection: Rectangle) => {
+    const [[left], [right]] = selection;
+    return (left === -1 && right === -1);
+};
+
+// Selection is infinite vertically
+export const isMaybeColumnSelection = (selection: Rectangle) => {
+    const [[, top], [, bottom]] = selection;
+    return (top === -1 && bottom === -1);
+};
+
+// Selection is ONLY infinite horizontally
+export const isRowSelection = (selection: Rectangle) => {
+    const [[left, top], [right, bottom]] = selection;
+    return (left === -1 && right === -1) && (top !== -1 && bottom !== -1);
+};
+
+// Selection is ONLY infinite vertically
+export const isColumnSelection = (selection: Rectangle) => {
+    const [[left, top], [right, bottom]] = selection;
+    return (top === -1 && bottom === -1) && (left !== -1 && right !== -1);
+};
+
+// Selection is not infinite
+export const isCellSelection = (selection: Rectangle) => {
+    const [[left, top], [right, bottom]] = selection;
+    return (left !== -1 && right !== -1) && (top !== -1 && bottom !== -1);
+};
+
+// Selection is null
+export const isEmptySelection = (selection: Rectangle) => {
+    const [[left, top], [right, bottom]] = selection;
+    return (left === -1 && right === -1) && (top === -1 && bottom === -1);
+};
+
+// Test cell inside selection (inclusive edges)
+export const isPointInsideSelection = (selection: Rectangle, point: XY) => {
+    const [[left, top], [right, bottom]] = normalizeSelection(selection);
+    const [x, y] = point;
+    return (x >= left && x <= right) && (y >= top && y <= bottom);
+};
+
+// Normalize rectangle to min/max pair
+export const normalizeSelection = (selection: Rectangle): Rectangle => {
+    let [[left, top], [right, bottom]] = selection;
+    if (left > right) {
+        [left, right] = [right, left];
+    }
+    if (top > bottom) {
+        [top, bottom] = [bottom, top];
+    }
+
+    return [[left, top], [right, bottom]];
+};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,7 @@
-import Sheet from '.'
+import Sheet from '.';
 
 describe('Sheet', () => {
-  it('is truthy', () => {
-    expect(Sheet).toBeTruthy()
-  })
-})
+    it('is truthy', () => {
+        expect(Sheet).toBeTruthy();
+    });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,14 +74,19 @@ export type SheetProps = {
     columnHeaderStyle?: RowOrColumnProperty<Style>;
     cellStyle?: CellProperty<Style>;
     readOnly?: CellProperty<boolean>;
+    canSizeColumn?: RowOrColumnProperty<boolean>;
+    canSizeRow?: RowOrColumnProperty<boolean>;
+    canOrderColumn?: RowOrColumnProperty<boolean>;
+    canOrderRow?: RowOrColumnProperty<boolean>;
     sourceData?: CellProperty<string | number | null>;
     displayData?: CellProperty<CellContentType>;
     editData?: CellProperty<string>;
     editKeys?: CellProperty<string>;
     sheetStyle?: SheetStyle;
+    secondarySelections?: Selection[];
+
     cacheLayout?: boolean,
     dontCommitEditOnSelectionChange?: boolean;
-    secondarySelections?: Selection[];
 
     inputComponent?: (
         x: number,
@@ -133,6 +138,11 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
     const columnHeaderStyle = useMemo(() => createRowOrColumnProp(props.columnHeaderStyle, {}), [
         props.columnHeaderStyle,
     ]);
+
+    const canSizeColumn = useMemo(() => createRowOrColumnProp(props.canSizeColumn, true), [props.canSizeColumn]);
+    const canSizeRow = useMemo(() => createRowOrColumnProp(props.canSizeRow, true), [props.canSizeRow]);
+    const canOrderColumn = useMemo(() => createRowOrColumnProp(props.canOrderColumn, true), [props.canOrderColumn]);
+    const canOrderRow = useMemo(() => createRowOrColumnProp(props.canOrderRow, true), [props.canOrderRow]);
 
     const cellReadOnly = useMemo(() => createCellProp(props.readOnly, false), [props.readOnly]);
 
@@ -265,6 +275,10 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
         editMode,
         editData,
         sourceData,
+        canSizeColumn,
+        canSizeRow,
+        canOrderColumn,
+        canOrderRow,
         cellLayout,
         visibleCells,
         sheetStyle,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -203,7 +203,7 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
     }, [visibleCells, props.onScrollChange]);
 
     // Set selection with scrolling
-    const changeSelection = (newSelection: Rectangle, scrollToHead = true) => {
+    const changeSelection = (newSelection: Rectangle, scrollToAnchor = true) => {
         if (!isSameSelection(selection, newSelection)) {
             setSelection(newSelection);
         }
@@ -211,11 +211,11 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
         const {current: overlay} = overlayRef;
         if (!overlay) return;
 
-        if (scrollToHead) {
-            const [, head] = newSelection;
+        if (scrollToAnchor) {
+            const [anchor] = newSelection;
             scrollToCell(
                 overlay,
-                head,
+                anchor,
                 [canvasWidth, canvasHeight],
                 [freezeColumns, freezeRows],
                 dataOffset,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,153 +1,73 @@
 import styles from './styles.module.css';
 import React, {
+    forwardRef,
     useRef,
-    useEffect,
+    useImperativeHandle,
+    useLayoutEffect,
     useState,
     useMemo,
-    MouseEvent,
     KeyboardEvent,
-    UIEvent,
-    CSSProperties,
+    KeyboardEventHandler,
     ReactElement,
 } from 'react';
 import useResizeObserver from 'use-resize-observer';
 
-const selBorderColor = '#1b73e7';
-const selBackColor = '#e9f0fd';
-const knobSize = 6;
-const gridColor = '#e2e3e3';
-const knobAreaBorderColor = '#707070';
-const kRowHeaderWidth = 50;
-const rowHeaderBackgroundColor = '#f8f9fa';
-const rowHeaderTextColor = '#666666';
-const rowHeaderSelectedBackgroundColor = '#e8eaed';
-const kColumnHeaderHeight = 22;
-const columnHeaderBackgroundColor = rowHeaderBackgroundColor;
-const columnHeaderSelectedBackgroundColor = rowHeaderSelectedBackgroundColor;
-const xBinSize = 10;
-const yBinSize = 10;
-const scrollSpeed = 30;
-const resizeColumnRowMouseThreshold = 4;
-const minimumColumnWidth = 50;
-const minimumRowHeight = 22;
-const rowColHeaderSelectionColor = '#cccccc';
-const maxSearchableRowOrCol = 65536;
+import {
+    XY,
+    Rectangle,
+    CellLayout,
+    CellProperty,
+    CellContentType,
+    RowOrColumnProperty,
+    Selection,
+    Clickable,
+    Change,
+    SheetPointerEvent,
+    InternalSheetStyle,
+    InputStyle,
+    SheetStyle,
+    Style,
+} from './types';
 
-const defaultCellStyle: Required<Style> = {
-    textAlign: 'left',
-    fontSize: 13,
-    marginRight: 5,
-    marginLeft: 5,
-    color: '#000',
-    fontFamily: 'sans-serif',
-    weight: '',
-    fillColor: '',
-    backgroundColor: '',
+import {
+    ARROW_KEYS,
+	MAX_SEARCHABLE_INDEX,
+	DEFAULT_CELL_STYLE,
+	INITIAL_MAX_SCROLL,
+	NO_CELL,
+    NO_CLICKABLES,
+	NO_SELECTION,
+    NO_SELECTIONS,
+	ORIGIN,
+    ONE_ONE,
+} from './constants';
+import {
+    normalizeSelection,
+    isSameSelection,
+    isRowSelection,
+    isColumnSelection,
+    isEmptySelection,
+    getDirectionStep,
+    maxXY,
+    addXY,
+} from './coordinate';
+import { useMouse } from './mouse';
+import { useScroll, scrollToCell } from './scroll';
+import { useClipboardCopy, useClipboardPaste } from './clipboard';
+import { makeLayoutCache, makeCellLayout } from './layout';
+import { createCellProp, createRowOrColumnProp, findInDisplayData } from './props';
+import { renderSheet } from './render';
+import { resolveSheetStyle } from './style';
+
+export type SheetInputProps = {
+    value: string,
+    autoFocus: boolean,
+    onKeyDown: KeyboardEventHandler<HTMLElement>,
+    onChange: (value: string) => void,
+    style: InputStyle,
 };
 
-const defaultColumnHeaderStyle: Required<Style> = {
-    textAlign: 'center',
-    fontSize: 13,
-    marginRight: 5,
-    marginLeft: 5,
-    color: '#000',
-    fontFamily: 'sans-serif',
-    weight: '',
-    fillColor: '',
-    backgroundColor: '',
-};
-
-type PropTypes = string | number | boolean | Style | CellContentType;
-type RowOrColumnProperty<T extends PropTypes> = T | Array<T> | ((index: number) => T);
-type CellProperty<T extends PropTypes> = T | Array<Array<T>> | ((x: number, y: number) => T);
-type CellContentType = null | number | string | CellContent;
-type RowOrColumnPropertyFunction<T extends PropTypes> = (rowOrColIndex: number) => T;
-type CellPropertyFunction<T extends PropTypes> = (x: number, y: number) => T;
-type InputStyle = Pick<
-    CSSProperties,
-    | 'position'
-    | 'top'
-    | 'left'
-    | 'width'
-    | 'height'
-    | 'outline'
-    | 'border'
-    | 'textAlign'
-    | 'color'
-    | 'fontSize'
-    | 'fontFamily'
->;
-export interface SheetInputProps {
-    value: string;
-    autoFocus: boolean;
-    onKeyDown: React.KeyboardEventHandler<HTMLElement>;
-    onChange: (valiue: string) => void;
-    style: InputStyle;
-}
-interface CellCoordinate {
-    x: number;
-    y: number;
-}
-
-interface SelectionSpan {
-    x1: number;
-    y1: number;
-    x2: number;
-    y2: number;
-}
-
-interface Selection {
-    span: SelectionSpan;
-    color: string;
-}
-
-export interface Change {
-    x: number;
-    y: number;
-    value: string | number | null;
-    source?: { x: number; y: number };
-}
-
-export interface CellContentItem {
-    content: HTMLImageElement | string | number;
-    x: number;
-    y: number;
-    width?: number;
-    height?: number;
-    horiozntalAlign?: 'left' | 'right' | 'center';
-    onClick?: (e: MouseEvent) => void;
-}
-
-export interface CellContent {
-    items: Array<CellContentItem>;
-}
-
-export interface SheetMouseEvent extends MouseEvent {
-    cellX: number;
-    cellY: number;
-}
-
-interface InternalSheetStyle {
-    hideGridlines: boolean;
-    hideColumnHeaders: boolean;
-    hideRowHeaders: boolean;
-    freezeColumns: number;
-    freezeRows: number;
-    columnHeaderHeight: number;
-    rowHeaderWidth: number;
-    hideScrollBars: boolean;
-}
-
-export interface SheetStyle {
-    hideGridlines?: boolean;
-    hideColumnHeaders?: boolean;
-    hideRowHeaders?: boolean;
-    freezeColumns?: number;
-    freezeRows?: number;
-    hideScrollBars?: boolean;
-}
-
-export interface SheetProps {
+export type SheetProps = {
     cellWidth?: RowOrColumnProperty<number>;
     cellHeight?: RowOrColumnProperty<number>;
     columnHeaders?: RowOrColumnProperty<CellContentType>;
@@ -159,1214 +79,244 @@ export interface SheetProps {
     editData?: CellProperty<string>;
     editKeys?: CellProperty<string>;
     sheetStyle?: SheetStyle;
+    cacheLayout?: boolean,
     dontCommitEditOnSelectionChange?: boolean;
     secondarySelections?: Selection[];
+
     inputComponent?: (
         x: number,
         y: number,
         props: SheetInputProps,
         commitEditingCell?: () => void
     ) => ReactElement | undefined;
-    onSelectionChanged?: (x1: number, y1: number, x2: number, y2: number) => void;
-    onRightClick?: (e: SheetMouseEvent) => void;
+
+    onSelectionChanged?: (minX: number, minY: number, maxX: number, maxY: number) => void;
+    onRightClick?: (e: SheetPointerEvent) => void;
     onChange?: (changes: Array<Change>) => void;
+    onColumnOrderChange?: (indices: number[], order: number) => void;
+    onRowOrderChange?: (indices: number[], order: number) => void;
     onCellWidthChange?: (indices: number[], value: number) => void;
     onCellHeightChange?: (indices: number[], value: number) => void;
     onScrollChange?: (visibleRows: number[], visibleColumns: number[]) => void;
-}
+};
 
-export interface Style {
-    color?: string;
-    fontSize?: number;
-    fontFamily?: string;
-    textAlign?: 'right' | 'left' | 'center';
-    marginRight?: number;
-    marginLeft?: number;
-    weight?: string;
-    fillColor?: string;
-    backgroundColor?: string;
-}
+export type SheetRef = CellLayout;
 
-interface RowOrColumnSize {
-    index: number[];
-    start: number[];
-    end: number[];
-}
-
-function resizeCanvas(canvas: HTMLCanvasElement) {
-    const { width, height } = canvas.getBoundingClientRect();
-    let { devicePixelRatio: ratio = 1 } = window;
-    if (ratio < 1) {
-        ratio = 1;
-    }
-    const newCanvasWidth = Math.round(width * ratio);
-    const newCanvasHeight = Math.round(height * ratio);
-
-    if (canvas.width !== newCanvasWidth || canvas.height !== newCanvasHeight) {
-        const context = canvas.getContext('2d');
-        if (context) {
-            canvas.width = newCanvasWidth;
-            canvas.height = newCanvasHeight;
-            context.scale(ratio, ratio);
-        }
-        return true;
-    }
-
-    return false;
-}
-
-// todo first figure out the function
-function createRowOrColumnPropFunction<T extends PropTypes>(
-    rowColProp: RowOrColumnProperty<T> | undefined,
-    defaultValue: T
-): RowOrColumnPropertyFunction<T> {
-    if (Array.isArray(rowColProp)) {
-        return (rowOrColIndex: number) => {
-            if (rowOrColIndex >= 0 && rowOrColIndex < rowColProp.length) {
-                return rowColProp[rowOrColIndex];
-            } else {
-                return defaultValue;
-            }
-        };
-    } else if (typeof rowColProp === 'function') {
-        return rowColProp;
-    } else if (rowColProp !== null && rowColProp !== undefined) {
-        return () => rowColProp;
-    } else {
-        return () => defaultValue;
-    }
-}
-
-function createCellPropFunction<T extends PropTypes>(
-    cellProp: CellProperty<T> | undefined,
-    defaultValue: T
-): CellPropertyFunction<T> {
-    if (Array.isArray(cellProp)) {
-        return (x: number, y: number) => {
-            if (y >= 0 && y < cellProp.length) {
-                if (x >= 0 && x < cellProp[y].length) {
-                    return cellProp[y][x];
-                } else {
-                    return defaultValue;
-                }
-            } else {
-                return defaultValue;
-            }
-        };
-    } else if (typeof cellProp === 'function') {
-        return cellProp;
-    } else if (cellProp !== null && cellProp !== undefined) {
-        return () => cellProp;
-    } else {
-        return () => defaultValue;
-    }
-}
-
-function applyAlignment(
-    start: number,
-    cellSize: number,
-    style: Required<Style>,
-    imageWidth: number,
-    alignment?: 'left' | 'center' | 'right'
-): number {
-    if (!alignment) {
-        alignment = style.textAlign;
-    }
-    if (alignment === 'left') {
-        return start + style.marginLeft;
-    } else if (alignment === 'center') {
-        return start + cellSize * 0.5 - imageWidth / 2;
-    } else if (alignment === 'right') {
-        return start + (cellSize - style.marginRight - imageWidth);
-    }
-    return start;
-}
-
-function drawCell(
-    context: CanvasRenderingContext2D,
-    cellContent: CellContentType,
-    style: Style,
-    defaultCellStyle: Required<Style>,
-    xCoord: number,
-    yCoord: number,
-    cellWidth: number,
-    cellHeight: number
-) {
-    if (cellContent === null) {
-        return;
-    }
-    const finalStyle = createStyleObject(style, defaultCellStyle);
-    context.fillStyle = finalStyle.color;
-    context.font = finalStyle.weight + ' ' + finalStyle.fontSize + 'px ' + finalStyle.fontFamily;
-    context.textAlign = finalStyle.textAlign;
-
-    const yy = yCoord + cellHeight * 0.5;
-
-    context.save();
-    context.beginPath();
-    context.rect(xCoord, yCoord, cellWidth, cellHeight);
-    context.clip();
-
-    if (finalStyle.backgroundColor !== '') {
-        context.fillStyle = finalStyle.backgroundColor;
-        context.fillRect(xCoord, yCoord, cellWidth, cellHeight);
-        context.fillStyle = finalStyle.color;
-    }
-
-    if (typeof cellContent === 'string' || typeof cellContent === 'number') {
-        const xx = applyAlignment(xCoord, cellWidth, finalStyle, 0);
-        context.fillText('' + cellContent, xx, yy);
-    } else if (typeof cellContent === 'object') {
-        for (const obj of cellContent.items) {
-            if (obj.content instanceof HTMLImageElement) {
-                const w = obj.width || cellWidth;
-                const finalX = applyAlignment(xCoord, cellWidth, finalStyle, w, obj.horiozntalAlign);
-                context.drawImage(
-                    obj.content,
-                    finalX + obj.x,
-                    yy + obj.y,
-                    obj.width || cellWidth,
-                    obj.height || cellHeight
-                );
-            } else if (typeof obj.content === 'string' || typeof obj.content === 'number') {
-                if (obj.horiozntalAlign) {
-                    context.textAlign = obj.horiozntalAlign;
-                }
-                const finalX = applyAlignment(xCoord, cellWidth, finalStyle, 0, obj.horiozntalAlign);
-                context.fillText('' + obj.content, finalX + obj.x, yy + obj.y);
-            }
-        }
-    }
-    context.restore();
-}
-
-function calculateRowsOrColsSizes(
-    freezeCount: number,
-    size: (index: number) => number,
-    startingSize: number,
-    startingIndex: number,
-    visibleArea: number
-): RowOrColumnSize {
-    const visible = [];
-    const start = [];
-    const end = [];
-    let prev = 0;
-
-    start.push(startingSize);
-    visible.push(freezeCount > 0 ? 0 : startingIndex);
-    let firstSize = freezeCount > 0 ? size(0) : size(startingIndex);
-    prev = startingSize + firstSize;
-    end.push(prev);
-
-    let ind = freezeCount > 0 ? 1 : startingIndex + 1;
-
-    if (freezeCount > 0) {
-        for (; ind < freezeCount; ind++) {
-            visible.push(ind);
-            start.push(prev);
-            prev = prev + size(ind);
-            end.push(prev);
-        }
-        ind = Math.max(startingIndex, freezeCount);
-    }
-
-    while (true) {
-        visible.push(ind);
-        start.push(prev);
-        prev = prev + size(ind);
-        end.push(prev);
-        if (end[end.length - 1] >= visibleArea) {
-            break;
-        }
-        ind++;
-    }
-    return {
-        index: visible,
-        start,
-        end,
-    };
-}
-
-function createStyleObject(optionalStyle: Style, defaultStyle: Required<Style>): Required<Style> {
-    return {
-        ...defaultStyle,
-        ...optionalStyle,
-    };
-}
-
-function excelHeaderString(num: number) {
-    let s = '';
-    let t = 0;
-    while (num > 0) {
-        t = (num - 1) % 26;
-        s = String.fromCharCode(65 + t) + s;
-        num = ((num - t) / 26) | 0;
-    }
-    return s || '';
-}
-
-function absCoordianteToCell(
-    absX: number,
-    absY: number,
-    rowSizes: RowOrColumnSize,
-    columnSizes: RowOrColumnSize
-): CellCoordinate {
-    let cellX = 0;
-    let cellY = 0;
-
-    for (let i = 0; i < columnSizes.index.length; i++) {
-        if (absX >= columnSizes.start[i] && absX <= columnSizes.end[i]) {
-            cellX = columnSizes.index[i];
-            break;
-        }
-    }
-    for (let i = 0; i < rowSizes.index.length; i++) {
-        if (absY >= rowSizes.start[i] && absY <= rowSizes.end[i]) {
-            cellY = rowSizes.index[i];
-            break;
-        }
-    }
-
-    return { x: cellX, y: cellY };
-}
-
-function normalizeSelection(selection: SelectionSpan) {
-    let selx1 = selection.x1;
-    let selx2 = selection.x2;
-
-    if (selection.x1 > selection.x2) {
-        selx1 = selection.x2;
-        selx2 = selection.x1;
-    }
-
-    let sely1 = selection.y1;
-    let sely2 = selection.y2;
-
-    if (selection.y1 > selection.y2) {
-        sely1 = selection.y2;
-        sely2 = selection.y1;
-    }
-    return [selx1, sely1, selx2, sely2];
-}
-
-function cellToAbsCoordinate(
-    cellX: number,
-    cellY: number,
-    rowSizes: RowOrColumnSize,
-    columnSizes: RowOrColumnSize,
-    dataOffset: CellCoordinate,
-    cellWidth: RowOrColumnPropertyFunction<number>,
-    cellHeight: RowOrColumnPropertyFunction<number>,
-    sheetStyle: InternalSheetStyle
-): CellCoordinate {
-    let absX = sheetStyle.rowHeaderWidth;
-    const indX = columnSizes.index.findIndex((i) => i === cellX);
-    if (indX !== -1) {
-        absX = columnSizes.start[indX];
-    } else {
-        for (let i = 0; i < dataOffset.x; i++) {
-            absX -= cellWidth(i);
-        }
-        for (let i = 0; i < cellX; i++) {
-            absX += cellWidth(i);
-        }
-    }
-
-    let absY = sheetStyle.columnHeaderHeight;
-    const indY = rowSizes.index.findIndex((i) => i === cellY);
-    if (indY !== -1) {
-        absY = rowSizes.start[indY];
-    } else {
-        for (let i = 0; i < dataOffset.y; i++) {
-            absY -= cellHeight(i);
-        }
-        for (let i = 0; i < cellY; i++) {
-            absY += cellHeight(i);
-        }
-    }
-    return { x: absX, y: absY };
-}
-
-function findApproxMaxEditDataIndex(editData: CellPropertyFunction<string>) {
-    let x = 0;
-    let y = 0;
-    let howManyEmpty = 0;
-    let growthIncrement = 10;
-    let growthIncrementFactor = 1.5;
-
-    // x
-    while (howManyEmpty < 4) {
-        let allEmpty = true;
-        for (let yy = 0; yy < 10; yy++) {
-            const data = editData(x, yy);
-            if (data !== null && data !== undefined && data !== '') {
-                allEmpty = false;
-                break;
-            }
-        }
-        if (allEmpty) {
-            howManyEmpty += 1;
-        }
-        x += growthIncrement;
-        if (x > maxSearchableRowOrCol) {
-            break;
-        }
-        growthIncrement = Math.floor(growthIncrement * growthIncrementFactor);
-    }
-
-    howManyEmpty = 0;
-    growthIncrement = 10;
-    growthIncrementFactor = 1.5;
-
-    // y
-    while (howManyEmpty < 4) {
-        let allEmpty = true;
-        for (let xx = 0; xx < 10; xx++) {
-            const data = editData(xx, y);
-            if (data !== null && data !== undefined && data !== '') {
-                allEmpty = false;
-                break;
-            }
-        }
-        if (allEmpty) {
-            howManyEmpty += 1;
-        }
-        y += growthIncrement;
-        if (y > maxSearchableRowOrCol) {
-            break;
-        }
-        growthIncrement = Math.floor(growthIncrement * growthIncrementFactor);
-    }
-    return { x, y };
-}
-
-function findInDisplayData(
-    displayData: CellPropertyFunction<CellContentType>,
-    start: { x: number; y: number },
-    direction: 'up' | 'down' | 'left' | 'right'
-) {
-    let i = { ...start };
-    let increment = { x: 0, y: 0 };
-    if (direction === 'up') {
-        increment.y = -1;
-    } else if (direction === 'down') {
-        increment.y = 1;
-    } else if (direction === 'left') {
-        increment.x = -1;
-    } else if (direction === 'right') {
-        increment.x = 1;
-    }
-    const max = { x: maxSearchableRowOrCol, y: maxSearchableRowOrCol };
-    if (i.x > max.x) {
-        i.x = max.x;
-    }
-    if (i.y > max.y) {
-        i.y = max.y;
-    }
-
-    const first = displayData(i.x + increment.x, i.y + increment.y);
-    const firstFilled = first !== '' && first !== null && first !== undefined;
-
-    if (!firstFilled) {
-        i.x += increment.x;
-        i.y += increment.y;
-    }
-
-    while (i.x <= max.x && i.y <= max.y && i.x >= 0 && i.y >= 0) {
-        const data = displayData(i.x, i.y);
-
-        // if first cell is filled, find the latest filled cell, so first look for first unfilled
-        if (firstFilled && (data === '' || data === null || data === undefined)) {
-            return {
-                x: i.x - increment.x,
-                y: i.y - increment.y,
-            };
-        }
-        // if first cell is not filled, just find the first filled
-        if (!firstFilled && data !== '' && data !== null && data !== undefined) {
-            return { ...i };
-        }
-
-        i.x += increment.x;
-        i.y += increment.y;
-    }
-    return i;
-}
-
-function renderOnCanvas(
-    context: CanvasRenderingContext2D,
-    rowSizes: RowOrColumnSize,
-    columnSizes: RowOrColumnSize,
-    cellStyle: CellPropertyFunction<Style>,
-    cellWidth: RowOrColumnPropertyFunction<number>,
-    cellHeight: RowOrColumnPropertyFunction<number>,
-    selection: SelectionSpan,
-    secondarySelections: Selection[],
-    knobDragInProgress: boolean,
-    columnHeaders: RowOrColumnPropertyFunction<CellContentType>,
-    columnHeaderStyle: RowOrColumnPropertyFunction<Style>,
-    knobArea: SelectionSpan,
-    displayData: CellPropertyFunction<CellContentType>,
-    dataOffset: CellCoordinate,
-    knobCoordinates: { x: number; y: number },
-    sheetStyle: InternalSheetStyle
-) {
-    resizeCanvas(context.canvas);
-    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
-    context.fillStyle = 'white';
-    context.fillRect(0, 0, context.canvas.width, context.canvas.height);
-
-    // apply cell fill color
-    let yCoord1 = sheetStyle.columnHeaderHeight;
-    for (const y of rowSizes.index) {
-        let xCoord1 = sheetStyle.rowHeaderWidth;
-        for (const x of columnSizes.index) {
-            const style = cellStyle(x, y);
-            if (style.fillColor) {
-                context.fillStyle = style.fillColor;
-                context.fillRect(xCoord1, yCoord1, cellWidth(x), cellHeight(y));
-            }
-            xCoord1 += cellWidth(x);
-        }
-        yCoord1 += cellHeight(y);
-    }
-
-    let hideKnob = false;
-
-    const [selx1, sely1, selx2, sely2] = normalizeSelection(selection);
-
-    const selectionActive = (selx1 !== -1 && selx2 !== -1) || (sely1 !== -1 && sely2 !== -1);
-
-    const rowSelectionActive = selx1 === -1 && selx2 === -1 && sely1 !== -1 && sely2 !== -1;
-    const colSelectionActive = selx1 !== -1 && selx2 !== -1 && sely1 === -1 && sely2 === -1;
-
-    const p1 = cellToAbsCoordinate(selx1, sely1, rowSizes, columnSizes, dataOffset, cellWidth, cellHeight, sheetStyle);
-    const p2 = cellToAbsCoordinate(selx2, sely2, rowSizes, columnSizes, dataOffset, cellWidth, cellHeight, sheetStyle);
-    p2.x += cellWidth(selx2);
-    p2.y += cellHeight(sely2);
-
-    if (p1.x >= p2.x) {
-        // recalculate if the selection span covers both frozen and unfrozen columns
-        p2.x = p1.x;
-        let currentCol = selx1;
-        while (columnSizes.index.includes(currentCol)) {
-            p2.x += cellWidth(currentCol);
-            currentCol++;
-        }
-        hideKnob = true;
-    }
-
-    if (p1.y >= p2.y) {
-        // recalculate if the selection span covers both frozen and unfrozen rows
-        p2.y = p1.y;
-        let currentRow = sely1;
-        while (rowSizes.index.includes(currentRow)) {
-            p2.y += cellHeight(currentRow);
-            currentRow++;
-        }
-        hideKnob = true;
-    }
-
-    // selection fill
-    if (selectionActive) {
-        context.fillStyle = selBackColor;
-        if (rowSelectionActive) {
-            const p1x = Math.max(-100, p1.x);
-            context.fillRect(p1x, p1.y, 100000, p2.y - p1.y);
-        } else if (colSelectionActive) {
-            const p1y = Math.max(0, p1.y);
-            context.fillRect(p1.x, p1y, p2.x - p1.x, 100000);
-        } else {
-            context.fillRect(p1.x, p1.y, p2.x - p1.x, p2.y - p1.y);
-        }
-    }
-
-    if (!sheetStyle.hideRowHeaders) {
-        // row header background
-        context.fillStyle = rowHeaderBackgroundColor;
-        context.fillRect(0, 0, sheetStyle.rowHeaderWidth, context.canvas.height);
-
-        // row header selection
-        if (selectionActive) {
-            context.fillStyle = rowHeaderSelectedBackgroundColor;
-            context.fillRect(0, p1.y, sheetStyle.rowHeaderWidth, p2.y - p1.y);
-        }
-    }
-
-    if (!sheetStyle.hideColumnHeaders) {
-        // column header background
-        context.fillStyle = columnHeaderBackgroundColor;
-        context.fillRect(0, 0, context.canvas.width, sheetStyle.columnHeaderHeight);
-
-        // column header selection
-        if (selectionActive) {
-            context.fillStyle = columnHeaderSelectedBackgroundColor;
-            context.fillRect(p1.x, 0, p2.x - p1.x, sheetStyle.columnHeaderHeight);
-        }
-    }
-
-    // grid
-    context.strokeStyle = gridColor;
-    context.lineWidth = 1;
-    let startX = sheetStyle.rowHeaderWidth;
-    let startY = sheetStyle.columnHeaderHeight;
-
-    let first = true;
-    const yGridlineEnd = sheetStyle.hideGridlines ? sheetStyle.columnHeaderHeight : context.canvas.height;
-    for (const col of columnSizes.index) {
-        context.beginPath();
-        context.moveTo(startX, 0);
-        if (first) {
-            if (!sheetStyle.hideRowHeaders) {
-                context.lineTo(startX, context.canvas.height);
-            }
-            first = false;
-        } else {
-            context.lineTo(startX, yGridlineEnd);
-        }
-        context.stroke();
-        startX += cellWidth(col);
-    }
-
-    const xGridlineEnd = sheetStyle.hideGridlines ? sheetStyle.rowHeaderWidth : context.canvas.width;
-    first = true;
-    for (const row of rowSizes.index) {
-        context.beginPath();
-        context.moveTo(0, startY);
-        if (first) {
-            if (!sheetStyle.hideColumnHeaders) {
-                context.lineTo(context.canvas.width, startY);
-            }
-            first = false;
-        } else {
-            context.lineTo(xGridlineEnd, startY);
-        }
-        context.stroke();
-        startY += cellHeight(row);
-    }
-
-    if (!sheetStyle.hideRowHeaders) {
-        // row header text
-        startY = sheetStyle.columnHeaderHeight;
-        context.textBaseline = 'middle';
-        context.textAlign = 'center';
-        context.font = defaultCellStyle.fontSize + 'px ' + defaultCellStyle.fontFamily;
-        context.fillStyle = rowHeaderTextColor;
-        for (const row of rowSizes.index) {
-            const cellContent = row + 1;
-            let chStyle = {};
-            if (rowSelectionActive && sely1 <= row && sely2 >= row) {
-                chStyle = { ...chStyle, backgroundColor: rowColHeaderSelectionColor };
-            }
-            drawCell(
-                context,
-                '' + cellContent,
-                chStyle,
-                defaultColumnHeaderStyle,
-                0,
-                startY,
-                sheetStyle.rowHeaderWidth,
-                cellHeight(row)
-            );
-            startY += cellHeight(row);
-        }
-    }
-
-    if (!sheetStyle.hideColumnHeaders) {
-        // column header text
-        startX = sheetStyle.rowHeaderWidth;
-        context.textBaseline = 'middle';
-        context.textAlign = 'center';
-        for (const col of columnSizes.index) {
-            const cw = cellWidth(col);
-            const ch = columnHeaders(col);
-            const chcontent = ch !== null ? ch : excelHeaderString(col + 1);
-            let chStyle = columnHeaderStyle(col);
-            if (colSelectionActive && selx1 <= col && selx2 >= col) {
-                chStyle = { ...chStyle, backgroundColor: rowColHeaderSelectionColor };
-            }
-            drawCell(
-                context,
-                chcontent,
-                chStyle,
-                defaultColumnHeaderStyle,
-                startX,
-                0,
-                cw,
-                sheetStyle.columnHeaderHeight
-            );
-            startX += cw;
-        }
-    }
-
-    // selection outline
-    if (selectionActive) {
-        context.strokeStyle = selBorderColor;
-        context.lineWidth = 1;
-        context.beginPath();
-        if (rowSelectionActive) {
-            const p1x = Math.max(-100, p1.x);
-            context.rect(p1x, p1.y, 100000, p2.y - p1.y);
-        } else if (colSelectionActive) {
-            const p1y = Math.max(-100, p1.y);
-            context.rect(p1.x, p1y, p2.x - p1.x, 100000);
-        } else {
-            context.rect(p1.x, p1.y, p2.x - p1.x, p2.y - p1.y);
-        }
-        context.stroke();
-    }
-
-    for (const secondarySelection of secondarySelections) {
-        const [selx1, sely1, selx2, sely2] = normalizeSelection(secondarySelection.span);
-
-        const secondarySelectionActive = (selx1 !== -1 && selx2 !== -1) || (sely1 !== -1 && sely2 !== -1);
-        if (!secondarySelectionActive) {
-            continue;
-        }
-        const rowSecondarySelectionActive = selx1 === -1 && selx2 === -1 && sely1 !== -1 && sely2 !== -1;
-        const colSecondarySelectionActive = selx1 !== -1 && selx2 !== -1 && sely1 === -1 && sely2 === -1;
-
-        const p1 = cellToAbsCoordinate(
-            selx1,
-            sely1,
-            rowSizes,
-            columnSizes,
-            dataOffset,
-            cellWidth,
-            cellHeight,
-            sheetStyle
-        );
-        const p2 = cellToAbsCoordinate(
-            selx2,
-            sely2,
-            rowSizes,
-            columnSizes,
-            dataOffset,
-            cellWidth,
-            cellHeight,
-            sheetStyle
-        );
-        p2.x += cellWidth(selx2);
-        p2.y += cellHeight(sely2);
-
-        if (p1.x >= p2.x) {
-            // recalculate if the selection span covers both frozen and unfrozen columns
-            p2.x = p1.x;
-            let currentCol = selx1;
-            while (columnSizes.index.includes(currentCol)) {
-                p2.x += cellWidth(currentCol);
-                currentCol++;
-            }
-        }
-
-        if (p1.y >= p2.y) {
-            // recalculate if the selection span covers both frozen and unfrozen rows
-            p2.y = p1.y;
-            let currentRow = sely1;
-            while (rowSizes.index.includes(currentRow)) {
-                p2.y += cellHeight(currentRow);
-                currentRow++;
-            }
-        }
-
-        context.strokeStyle = secondarySelection.color;
-        context.lineWidth = 1;
-        context.beginPath();
-
-        if (rowSecondarySelectionActive) {
-            const p1x = Math.max(-100, p1.x);
-            context.rect(p1x, p1.y, 100000, p2.y - p1.y);
-        } else if (colSecondarySelectionActive) {
-            const p1y = Math.max(-100, p1.y);
-            context.rect(p1.x, p1y, p2.x - p1.x, 100000);
-        } else {
-            context.rect(p1.x, p1.y, p2.x - p1.x, p2.y - p1.y);
-        }
-        context.stroke();
-    }
-
-    // knob drag outline
-    if (knobDragInProgress) {
-        let kx1 = knobArea.x1;
-        let kx2 = knobArea.x2;
-        if (knobArea.x1 > knobArea.x2) {
-            kx1 = knobArea.x2;
-            kx2 = knobArea.x1;
-        }
-
-        let ky1 = knobArea.y1;
-        let ky2 = knobArea.y2;
-        if (knobArea.y1 > knobArea.y2) {
-            ky1 = knobArea.y2;
-            ky2 = knobArea.y1;
-        }
-        const knobPoint1 = cellToAbsCoordinate(
-            kx1,
-            ky1,
-            rowSizes,
-            columnSizes,
-            dataOffset,
-            cellWidth,
-            cellHeight,
-            sheetStyle
-        );
-        const knobPoint2 = cellToAbsCoordinate(
-            kx2 + 1,
-            ky2 + 1,
-            rowSizes,
-            columnSizes,
-            dataOffset,
-            cellWidth,
-            cellHeight,
-            sheetStyle
-        );
-        context.strokeStyle = knobAreaBorderColor;
-        context.setLineDash([3, 3]);
-        context.lineWidth = 1;
-        context.beginPath();
-        if (rowSelectionActive) {
-            context.rect(knobPoint1.x, knobPoint1.y - 1, 100000, knobPoint2.y - knobPoint1.y);
-        } else if (colSelectionActive) {
-            context.rect(knobPoint1.x, knobPoint1.y - 1, knobPoint2.x - knobPoint1.x, 100000);
-        } else {
-            context.rect(knobPoint1.x, knobPoint1.y - 1, knobPoint2.x - knobPoint1.x, knobPoint2.y - knobPoint1.y);
-        }
-        context.stroke();
-        context.setLineDash([]);
-    }
-
-    // selection knob
-    if (selectionActive && !hideKnob) {
-        context.fillStyle = selBorderColor;
-        context.fillRect(knobCoordinates.x - knobSize * 0.5, knobCoordinates.y - knobSize * 0.5, knobSize, knobSize);
-    }
-
-    // content
-    context.textBaseline = 'middle';
-
-    // draw content
-    let yCoord = sheetStyle.columnHeaderHeight;
-    for (const y of rowSizes.index) {
-        let xCoord = sheetStyle.rowHeaderWidth;
-        const ch = cellHeight(y);
-        for (const x of columnSizes.index) {
-            const cellContent = displayData(x, y);
-            const cw = cellWidth(x);
-            if (cellContent !== null && cellContent !== undefined) {
-                const style = cellStyle(x, y);
-                drawCell(context, cellContent, style, defaultCellStyle, xCoord, yCoord, cw, ch);
-            }
-            xCoord += cw;
-        }
-        yCoord += ch;
-    }
-}
-
-function Sheet(props: SheetProps) {
+const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const overlayRef = useRef<HTMLDivElement>(null);
-    const copyPasteTextAreaRef = useRef<HTMLTextAreaElement>(null);
-    const [maxScroll, setMaxScroll] = useState({ x: 5000, y: 5000 });
-    const [dataOffset, setDataOffset] = useState({ x: 0, y: 0 });
-    const [selection, setSelection] = useState<SelectionSpan>({ x1: -1, y1: -1, x2: -1, y2: -1 });
-    const [knobArea, setKnobArea] = useState<SelectionSpan>({ x1: -1, y1: -1, x2: -1, y2: -1 });
-    const [editCell, setEditCell] = useState({ x: -1, y: -1 });
+
+    const [maxScroll, setMaxScroll] = useState<XY>(INITIAL_MAX_SCROLL);
+    const [dataOffset, setDataOffset] = useState<XY>(ORIGIN);
+    // TODO: smooth scrolling
+    // const [pixelOffset, setPixelOffset] = useState<XY>(ORIGIN);
+
+    const [selection, setSelection] = useState<Rectangle>(NO_SELECTION);
+    const [knobArea, setKnobArea] = useState<Rectangle | null>(null);
+    const [dragOffset, setDragOffset] = useState<XY | null>(null);
+    const [dropTarget, setDropTarget] = useState<Rectangle | null>(null);
+    const [editCell, setEditCell] = useState<XY>(NO_CELL);
+
     const [editValue, setEditValue] = useState<string | number>('');
-    const [editKey, setEditKey] = useState<string>('');
     const [arrowKeyCommitMode, setArrowKeyCommitMode] = useState(false);
-    const [shiftKeyDown, setShiftKeyDown] = useState(false);
-    const [knobDragInProgress, setKnobDragInProgress] = useState(false);
-    const [selectionInProgress, setSelectionInProgress] = useState(false);
-    const [columnResize, setColumnResize] = useState<{ startX: number; colIndices: number[]; oldWidth: number } | null>(
-        null
-    );
-    const [rowResize, setRowResize] = useState<{ startY: number; rowIndices: number[]; oldHeight: number } | null>(
-        null
-    );
-    const [rowSelectionInProgress, setRowSelectionInProgress] = useState(false);
-    const [columnSelectionInProgress, setColumnSelectionInProgress] = useState(false);
-    const [buttonClickMouseDownCoordinates, setButtonClickMouseDownCoordinates] = useState<any>({
-        x: -1,
-        y: -1,
-        hitTarget: null,
-    });
+
     const { width: canvasWidth = 3000, height: canvasHeight = 3000 } = useResizeObserver({ ref: canvasRef });
 
     //    const freezeColumns = props.freezeColumns || 0;
     //    const freezeRows = props.freezeRows || 0;
 
-    const cellWidth = useMemo(() => createRowOrColumnPropFunction(props.cellWidth, 100), [props.cellWidth]);
-    const cellHeight = useMemo(() => createRowOrColumnPropFunction(props.cellHeight, 22), [props.cellHeight]);
-    const columnHeaders = useMemo(() => createRowOrColumnPropFunction(props.columnHeaders, null), [
+    const cellWidth = useMemo(() => createRowOrColumnProp(props.cellWidth, 100), [props.cellWidth]);
+    const cellHeight = useMemo(() => createRowOrColumnProp(props.cellHeight, 22), [props.cellHeight]);
+    const columnHeaders = useMemo(() => createRowOrColumnProp(props.columnHeaders, null), [
         props.columnHeaders,
     ]);
-    const columnHeaderStyle = useMemo(() => createRowOrColumnPropFunction(props.columnHeaderStyle, {}), [
+    const columnHeaderStyle = useMemo(() => createRowOrColumnProp(props.columnHeaderStyle, {}), [
         props.columnHeaderStyle,
     ]);
 
-    const cellReadOnly = useMemo(() => createCellPropFunction(props.readOnly, false), [props.readOnly]);
+    const cellReadOnly = useMemo(() => createCellProp(props.readOnly, false), [props.readOnly]);
 
-    const sourceData = useMemo(() => createCellPropFunction(props.sourceData, null), [props.sourceData]);
-    const displayData = useMemo(() => createCellPropFunction(props.displayData, ''), [props.displayData]);
-    const editData = useMemo(() => createCellPropFunction(props.editData, ''), [props.editData]);
-    const editKeys = useMemo(() => createCellPropFunction(props.editKeys, ''), [props.editKeys]);
-    const cellStyle = useMemo(() => createCellPropFunction(props.cellStyle, defaultCellStyle), [props.cellStyle]);
+    const sourceData = useMemo(() => createCellProp(props.sourceData, null), [props.sourceData]);
+    const displayData = useMemo(() => createCellProp(props.displayData, ''), [props.displayData]);
+    const editData = useMemo(() => createCellProp(props.editData, ''), [props.editData]);
+    const editKeys = useMemo(() => createCellProp(props.editKeys, ''), [props.editKeys]);
+    const cellStyle = useMemo(() => createCellProp(props.cellStyle, DEFAULT_CELL_STYLE), [props.cellStyle]);
 
-    const sheetStyle: InternalSheetStyle = useMemo(() => {
-        return {
-            freezeColumns: props.sheetStyle?.freezeColumns || 0,
-            freezeRows: props.sheetStyle?.freezeRows || 0,
-            hideColumnHeaders: props.sheetStyle?.hideColumnHeaders || false,
-            hideRowHeaders: props.sheetStyle?.hideRowHeaders || false,
-            hideGridlines: props.sheetStyle?.hideGridlines || false,
-            columnHeaderHeight: props.sheetStyle?.hideColumnHeaders ? 1 : kColumnHeaderHeight,
-            rowHeaderWidth: props.sheetStyle?.hideRowHeaders ? 1 : kRowHeaderWidth,
-            hideScrollBars: props.sheetStyle?.hideScrollBars || false,
-        };
-    }, [
-        props.sheetStyle?.freezeColumns,
-        props.sheetStyle?.freezeRows,
-        props.sheetStyle?.hideColumnHeaders,
-        props.sheetStyle?.hideGridlines,
-        props.sheetStyle?.hideRowHeaders,
-        props.sheetStyle?.hideScrollBars,
-    ]);
+    const sheetStyle: InternalSheetStyle = useMemo(() => resolveSheetStyle(props.sheetStyle), [props.sheetStyle]);
+    const secondarySelections = props.secondarySelections ?? NO_SELECTIONS;
 
-    useEffect(() => {
-        const currEditKey = editKeys ? editKeys(editCell.x, editCell.y) : '';
-        if (currEditKey !== editKey) {
-            setEditCell({ x: -1, y: -1 });
-            setEditKey('');
-        }
-    }, [editKeys]);
+    const [maxScrollX, maxScrollY] = maxScroll;
 
-    const columnSizes = useMemo(
-        () =>
-            calculateRowsOrColsSizes(
-                sheetStyle.freezeColumns,
-                cellWidth,
-                sheetStyle.rowHeaderWidth,
-                dataOffset.x,
-                canvasWidth
-            ),
-        [sheetStyle, cellWidth, dataOffset.x, canvasWidth]
+    const [editCellX, editCellY] = editCell;
+    const editMode = editCellX !== -1 && editCellY !== -1;
+
+    // Global layout for unscrolled/unfrozen grid
+    // Cached either per width/height pair, or permanently with invalidation on resize/reorder.
+    const columnLayout = useMemo(() => makeLayoutCache(cellWidth), [props.cacheLayout ? null : cellWidth]);
+    const rowLayout = useMemo(() => makeLayoutCache(cellHeight), [props.cacheLayout ? null : cellHeight]);
+    useMemo(() => {
+        if (!props.cacheLayout) return;
+        columnLayout.setSizer(cellWidth);
+        rowLayout.setSizer(cellHeight);
+    }, [props.cacheLayout, cellWidth, cellHeight])
+
+    // Virtual layout for indented/scrolled/frozen grid
+    const {freezeColumns, freezeRows, rowHeaderWidth, columnHeaderHeight} = sheetStyle;
+    const cellLayout = useMemo(
+        () => makeCellLayout(
+            [freezeColumns, freezeRows],
+            [rowHeaderWidth, columnHeaderHeight],
+            dataOffset,
+            columnLayout,
+            rowLayout,
+        ),
+        [freezeColumns, freezeRows, rowHeaderWidth, columnHeaderHeight, dataOffset, columnLayout, rowLayout]
     );
 
-    const rowSizes = useMemo(
-        () =>
-            calculateRowsOrColsSizes(
-                sheetStyle.freezeRows,
-                cellHeight,
-                sheetStyle.columnHeaderHeight,
-                dataOffset.y,
-                canvasHeight
-            ),
-        [sheetStyle, cellHeight, dataOffset.y, canvasHeight]
+    // External component API
+    useImperativeHandle(ref, () => cellLayout, [cellLayout]);
+
+    // Build range of visible cells
+    const {getVisibleCells, cellToPixel, getVersion} = cellLayout;
+    const visibleCells = useMemo(
+        () => getVisibleCells([canvasWidth, canvasHeight]),
+        // Need to invalidate view if cached layout version changed
+        // eslint-disable-next-line
+        [getVisibleCells, canvasWidth, canvasHeight, getVersion()]
     );
 
-    useEffect(() => {
+    // Notify of viewport change
+    useLayoutEffect(() => {
         if (props.onScrollChange) {
-            props.onScrollChange([...rowSizes.index], [...columnSizes.index]);
+            props.onScrollChange([...visibleCells.rows], [...visibleCells.columns]);
         }
-    }, [rowSizes, columnSizes, props.onScrollChange]);
+    }, [visibleCells, props.onScrollChange]);
 
-    const changeSelection = (x1: number, y1: number, x2: number, y2: number, scrollToP2 = true) => {
-        if (selection.x1 !== x1 || selection.x2 !== x2 || selection.y1 !== y1 || selection.y2 !== y2) {
-            setSelection({ x1, y1, x2, y2 });
+    // Set selection with scrolling
+    const changeSelection = (newSelection: Rectangle, scrollToHead = true) => {
+        if (!isSameSelection(selection, newSelection)) {
+            setSelection(newSelection);
         }
 
-        if (scrollToP2) {
-            const newDataOffset = { x: dataOffset.x, y: dataOffset.y };
-            let newScrollLeft = -1;
-            let newScrollTop = -1;
+        const {current: overlay} = overlayRef;
+        if (!overlay) return;
 
-            if (
-                x2 !== -1 &&
-                (!columnSizes.index.includes(x2) || columnSizes.index[columnSizes.index.length - 1] === x2)
-            ) {
-                const lastVisibleColumnIndex = columnSizes.index[columnSizes.index.length - 1];
-                const firstVisibleColumnIndex = columnSizes.index[sheetStyle.freezeColumns];
-                let increment = 0;
-                if (x2 >= lastVisibleColumnIndex) {
-                    increment = 1 + x2 - lastVisibleColumnIndex;
-                } else if (x2 < firstVisibleColumnIndex) {
-                    increment = x2 - firstVisibleColumnIndex;
-                }
-                const newX = Math.max(dataOffset.x, sheetStyle.freezeColumns) + increment;
-                newDataOffset.x = newX;
-                newScrollLeft = newX * scrollSpeed;
-            }
-
-            if (y2 !== -1 && (!rowSizes.index.includes(y2) || rowSizes.index[rowSizes.index.length - 1] === y2)) {
-                const firstVisibleRowIndex = rowSizes.index[sheetStyle.freezeRows];
-                const lastVisibleRowIndex = rowSizes.index[rowSizes.index.length - 1];
-                let increment = 0;
-                if (y2 >= lastVisibleRowIndex) {
-                    increment = 1 + y2 - lastVisibleRowIndex;
-                } else if (y2 < firstVisibleRowIndex) {
-                    increment = y2 - firstVisibleRowIndex;
-                }
-                const newY = Math.max(dataOffset.y, sheetStyle.freezeRows) + increment;
-                newDataOffset.y = newY;
-                newScrollTop = newY * scrollSpeed;
-            }
-
-            if (newDataOffset.x !== dataOffset.x || dataOffset.y !== newDataOffset.y) {
-                setDataOffset({ x: newDataOffset.x, y: newDataOffset.y });
-                const newMaxScroll = { ...maxScroll };
-                newMaxScroll.x = Math.max(newMaxScroll.x, newScrollLeft);
-                newMaxScroll.y = Math.max(newMaxScroll.y, newScrollTop);
-                setMaxScroll(newMaxScroll);
-                setTimeout(() => {
-                    if (overlayRef.current) {
-                        if (newScrollLeft !== -1) {
-                            overlayRef.current.scrollLeft = newScrollLeft;
-                        }
-                        if (newScrollTop !== -1) {
-                            overlayRef.current.scrollTop = newScrollTop;
-                        }
-                    }
-                }, 0);
-            }
+        if (scrollToHead) {
+            const [, head] = newSelection;
+            scrollToCell(
+                overlay,
+                head,
+                [canvasWidth, canvasHeight],
+                [freezeColumns, freezeRows],
+                dataOffset,
+                maxScroll,
+                cellLayout,
+                (dataOffset: XY, maxScroll: XY) => {
+                    setDataOffset(dataOffset);
+                    setMaxScroll(maxScroll);
+                },
+            );
         }
 
         if (props.onSelectionChanged) {
-            let sx1 = x1;
-            let sy1 = y1;
-            let sx2 = x2;
-            let sy2 = y2;
-            if (sx1 > sx2) {
-                sx1 = x2;
-                sx2 = x1;
-            }
-            if (sy1 > sy2) {
-                sy1 = y2;
-                sy2 = y1;
-            }
-            props.onSelectionChanged(sx1, sy1, sx2, sy2);
+            const [[minX, minY], [maxX, maxY]] = normalizeSelection(newSelection);
+            props.onSelectionChanged(minX, minY, maxX, maxY);
         }
     };
 
-    const knobCoordinates = useMemo(() => {
-        if (selection.x1 === -1 && selection.x2 === -1 && selection.y1 !== -1 && selection.y2 !== -1) {
-            let sely2 = selection.y2;
-            if (selection.y1 > selection.y2) {
-                sely2 = selection.y1;
-            }
-            const c = cellToAbsCoordinate(
-                0,
-                sely2,
-                rowSizes,
-                columnSizes,
-                dataOffset,
-                cellWidth,
-                cellHeight,
-                sheetStyle
-            );
-            return { x: c.x + knobSize * 0.5, y: c.y + cellHeight(sely2) };
+    const commitEditingCell = (value?: string) => {
+        if (props.onChange) {
+            const [cellX, cellY] = editCell;
+            props.onChange([{ x: cellX, y: cellY, value: value !== undefined ? value : editValue }]);
         }
-        if (selection.x1 !== -1 && selection.x2 !== -1 && selection.y1 === -1 && selection.y2 === -1) {
-            let selx2 = selection.x2;
-            if (selection.x1 > selection.x2) {
-                selx2 = selection.x1;
-            }
+        setEditCell(NO_CELL);
+    };
 
-            const c = cellToAbsCoordinate(
-                selx2,
-                0,
-                rowSizes,
-                columnSizes,
-                dataOffset,
-                cellWidth,
-                cellHeight,
-                sheetStyle
-            );
-            return { x: c.x + cellWidth(selx2), y: c.y + knobSize * 0.5 };
-        }
-        if (selection.x2 !== -1 && selection.y2 !== -1) {
-            let selx2 = selection.x2;
-            if (selection.x1 > selection.x2) {
-                selx2 = selection.x1;
-            }
-
-            let sely2 = selection.y2;
-            if (selection.y1 > selection.y2) {
-                sely2 = selection.y1;
-            }
-            const c = cellToAbsCoordinate(
-                selx2,
-                sely2,
-                rowSizes,
-                columnSizes,
-                dataOffset,
-                cellWidth,
-                cellHeight,
-                sheetStyle
-            );
-            return { x: c.x + cellWidth(selx2), y: c.y + cellHeight(sely2) };
-        }
-        return { x: -1, y: -1 };
-    }, [selection, rowSizes, columnSizes, dataOffset, cellWidth, cellHeight, sheetStyle]);
-
-    const hitMap = useMemo(() => {
-        const hitM = {};
-        const canvas = canvasRef.current;
-        if (!canvas) {
-            return hitM;
-        }
-        resizeCanvas(canvas);
-        let yCoord = sheetStyle.columnHeaderHeight;
-        let xCoord = sheetStyle.rowHeaderWidth;
-
-        for (const x of columnSizes.index) {
-            const ch = columnHeaders(x);
-            const cellW = cellWidth(x);
-            if (ch && typeof ch === 'object' && ch.items) {
-                let finalStyle;
-                for (const obj of ch.items) {
-                    if (obj.onClick) {
-                        if (!finalStyle) {
-                            finalStyle = createStyleObject(columnHeaderStyle(x), defaultCellStyle);
-                        }
-                        const w = obj.content instanceof HTMLImageElement ? obj.width || cellW : 0;
-                        const absX1 = applyAlignment(xCoord, cellW, finalStyle, w, obj.horiozntalAlign) + obj.x;
-                        const absY1 = sheetStyle.columnHeaderHeight * 0.5 + obj.y;
-                        const absX2 = absX1 + (obj.width || 0);
-                        const absY2 = absY1 + (obj.height || 0);
-
-                        const hitTarget = {
-                            x: absX1,
-                            y: absY1,
-                            w: obj.width,
-                            h: obj.height,
-                            onClick: obj.onClick,
-                        };
-
-                        // add to hit map
-                        const x1key = Math.floor(absX1 / xBinSize);
-                        const x2key = Math.floor(absX2 / xBinSize);
-
-                        const y1key = Math.floor(absY1 / yBinSize);
-                        const y2key = Math.floor(absY2 / yBinSize);
-
-                        for (let xkey = x1key; xkey <= x2key; xkey++) {
-                            if (!hitM[xkey]) {
-                                hitM[xkey] = {};
-                            }
-                            const xbin = hitM[xkey];
-                            for (let ykey = y1key; ykey <= y2key; ykey++) {
-                                if (!xbin[ykey]) {
-                                    xbin[ykey] = [];
-                                }
-                                xbin[ykey].push(hitTarget);
-                            }
-                        }
-                    }
-                }
-            }
-            xCoord += cellW;
+    const startEditingCell = (editCell: XY, arrowKeyCommitMode = false) => {
+        const [cellX, cellY] = editCell;
+        if (cellReadOnly(cellX, cellY)) {
+            return;
         }
 
-        for (const y of rowSizes.index) {
-            xCoord = sheetStyle.rowHeaderWidth;
-            for (const x of columnSizes.index) {
-                const cellContent = displayData(x, y);
-                const cellW = cellWidth(x);
-                if (cellContent === null || cellContent === undefined) {
-                    xCoord += cellW;
-                    continue;
-                }
-
-                const xx = xCoord;
-                const yy = yCoord + cellHeight(y) * 0.5;
-
-                if (typeof cellContent === 'object' && cellContent.items) {
-                    let finalStyle;
-                    for (const obj of cellContent.items) {
-                        if (obj.onClick) {
-                            if (!finalStyle) {
-                                finalStyle = createStyleObject(cellStyle(x, y), defaultCellStyle);
-                            }
-                            const w = obj.content instanceof HTMLImageElement ? obj.width || cellW : 0;
-                            const absX1 = applyAlignment(xx, cellW, finalStyle, w, obj.horiozntalAlign) + obj.x;
-                            const absY1 = yy + obj.y;
-                            const absX2 = absX1 + (obj.width || 0);
-                            const absY2 = absY1 + (obj.height || 0);
-
-                            const hitTarget = {
-                                x: absX1,
-                                y: absY1,
-                                w: obj.width,
-                                h: obj.height,
-                                onClick: obj.onClick,
-                            };
-
-                            // add to hit map
-                            const x1key = Math.floor(absX1 / xBinSize);
-                            const x2key = Math.floor(absX2 / xBinSize);
-
-                            const y1key = Math.floor(absY1 / yBinSize);
-                            const y2key = Math.floor(absY2 / yBinSize);
-
-                            for (let xkey = x1key; xkey <= x2key; xkey++) {
-                                if (!hitM[xkey]) {
-                                    hitM[xkey] = {};
-                                }
-                                const xbin = hitM[xkey];
-                                for (let ykey = y1key; ykey <= y2key; ykey++) {
-                                    if (!xbin[ykey]) {
-                                        xbin[ykey] = [];
-                                    }
-                                    xbin[ykey].push(hitTarget);
-                                }
-                            }
-                        }
-                    }
-                }
-                xCoord += cellW;
-            }
-            yCoord += cellHeight(y);
+        const editDataValue = editData(cellX, cellY);
+        let val = '';
+        if (editDataValue !== null && editDataValue !== undefined) {
+            val = editDataValue;
         }
-        return hitM;
-    }, [
-        displayData,
-        props.cellWidth,
-        props.cellHeight,
-        canvasRef,
-        columnSizes,
-        rowSizes,
-        dataOffset.x,
-        dataOffset.y,
+        setEditCell(editCell);
+        setEditValue(val);
+        setArrowKeyCommitMode(arrowKeyCommitMode);
+    };
+
+    // Output from rendered layout is used to drive events on user content
+    const hitmapRef = useRef<Clickable[]>(NO_CLICKABLES);
+
+    // Textarea is used to hold text to copy, and receives pastes
+    const textAreaRef = useRef<HTMLTextAreaElement>(null);
+    useClipboardCopy(textAreaRef, selection, editMode, editData);
+    useClipboardPaste(textAreaRef, selection, changeSelection, props.onChange);
+
+    const onScroll = useScroll(dataOffset, maxScroll, cellLayout, setDataOffset, setMaxScroll);
+
+    const {mouseHandlers, knobPosition} = useMouse(
+        hitmapRef,
+        selection,
+        knobArea,
+        editMode,
+        editData,
+        sourceData,
+        cellLayout,
+        visibleCells,
         sheetStyle,
-    ]);
 
-    useEffect(() => {
-        const canvas = canvasRef.current;
+        startEditingCell,
+        commitEditingCell,
+        setKnobArea,
+        setDragOffset,
+        setDropTarget,
+        changeSelection,
+
+        props.cacheLayout ? columnLayout.clearAfter : undefined,
+        props.cacheLayout ? rowLayout.clearAfter : undefined,
+
+        props.onChange,
+        props.onColumnOrderChange,
+        props.onRowOrderChange,
+        props.onCellWidthChange,
+        props.onCellHeightChange,
+        props.onRightClick,
+        props.dontCommitEditOnSelectionChange,
+    );
+
+    useLayoutEffect(() => {
+        const {current: canvas} = canvasRef;
         if (!canvas) {
             return;
         }
+
         const context = canvas.getContext('2d');
         if (!context) {
             return;
         }
-        let animationFrameId = window.requestAnimationFrame(() => {
-            renderOnCanvas(
+
+        const animationFrameId = window.requestAnimationFrame(() => {
+            hitmapRef.current = renderSheet(
                 context,
-                rowSizes,
-                columnSizes,
+                cellLayout,
+                visibleCells,
+                sheetStyle,
                 cellStyle,
-                cellWidth,
-                cellHeight,
                 selection,
-                props.secondarySelections || [],
-                knobDragInProgress,
+                secondarySelections,
+                knobPosition,
+                knobArea,
+                dragOffset,
+                dropTarget,
                 columnHeaders,
                 columnHeaderStyle,
-                knobArea,
                 displayData,
+
                 dataOffset,
-                knobCoordinates,
-                sheetStyle
             );
         });
 
@@ -1374,794 +324,51 @@ function Sheet(props: SheetProps) {
             window.cancelAnimationFrame(animationFrameId);
         };
     }, [
-        canvasRef,
-        rowSizes,
-        columnSizes,
+        cellLayout,
+        visibleCells,
+        sheetStyle,
         cellStyle,
-        cellWidth,
-        cellHeight,
         selection,
-        props.secondarySelections,
-        knobDragInProgress,
+        secondarySelections,
+
+        knobPosition,
+        knobArea,
+        dragOffset,
+        dropTarget,
+
         columnHeaders,
         columnHeaderStyle,
-        knobArea,
         displayData,
+
         dataOffset,
-        knobCoordinates,
-        sheetStyle,
     ]);
 
-    const setFocusToTextArea = () => {
-        if (copyPasteTextAreaRef.current) {
-            copyPasteTextAreaRef.current.focus({ preventScroll: true });
-            copyPasteTextAreaRef.current.select();
-        }
-    };
-
-    useEffect(() => {
-        if (!editMode) {
-            setCopyPasteText();
-        }
-    }, [selection, editData]);
-
-    useEffect(() => {
-        if (!editMode) {
-            if (document.activeElement === copyPasteTextAreaRef.current) {
-                setFocusToTextArea();
-            } else {
-                const activeTagName = (document as any).activeElement.tagName.toLowerCase();
-                if (
-                    !(
-                        (activeTagName === 'div' && (document as any).activeElement.contentEditable === 'true') ||
-                        activeTagName === 'input' ||
-                        activeTagName === 'textarea' ||
-                        activeTagName === 'select'
-                    )
-                ) {
-                    setFocusToTextArea();
-                }
-            }
-        }
-    });
-
-    const onPaste = (e: any) => {
-        if (!copyPasteTextAreaRef) {
-            return;
-        }
-        if (e.target !== copyPasteTextAreaRef.current) {
-            return;
-        }
-        e.preventDefault();
-
-        const clipboardData = e.clipboardData || (window as any).clipboardData;
-        const types = clipboardData.types;
-
-        if (types.includes('text/html')) {
-            const pastedHtml = clipboardData.getData('text/html');
-            parsePastedHtml(pastedHtml);
-        } else if (types.includes('text/plain')) {
-            const text = clipboardData.getData('text/plain');
-            parsePastedText(text);
-        }
-    };
-
-    useEffect(() => {
-        window.document.addEventListener('paste', onPaste);
-        return () => {
-            window.document.removeEventListener('paste', onPaste);
-        };
-    });
-
-    const findTable = (element: any): any => {
-        for (const child of element.children) {
-            if (child.nodeName === 'TABLE') {
-                return child;
-            }
-            const maybeTable = findTable(child);
-            if (maybeTable) {
-                return maybeTable;
-            }
-        }
-    };
-
-    const parsePastedHtml = (html: string) => {
-        const div = document.createElement('div');
-        div.innerHTML = html.trim();
-        let pasteLocX = -1;
-        let pasteLocY = -1;
-        if (selection.x1 !== -1 && selection.x2 === -1) {
-            pasteLocX = selection.x1;
-        }
-        if (selection.y1 !== -1 && selection.y2 === -1) {
-            pasteLocY = selection.y1;
-        }
-        if (selection.x1 !== -1 && selection.x2 !== -1) {
-            pasteLocX = Math.min(selection.x1, selection.x2);
-        }
-        if (selection.y1 !== -1 && selection.y2 !== -1) {
-            pasteLocY = Math.min(selection.y1, selection.y2);
-        }
-        if (pasteLocX === -1 || pasteLocY === -1) {
-            return;
-        }
-
-        let x = pasteLocX;
-        let y = pasteLocY;
-        const changes = [];
-
-        const tableNode = findTable(div);
-        if (!tableNode) {
-            return;
-        }
-
-        for (const tableChild of tableNode.children) {
-            if (tableChild.nodeName === 'TBODY') {
-                for (const tr of tableChild.children) {
-                    x = pasteLocX;
-                    if (tr.nodeName === 'TR') {
-                        for (const td of tr.children) {
-                            if (td.nodeName === 'TD') {
-                                let str: string = '';
-                                if (td.children.length !== 0 && td.children[0].nodeName === 'P') {
-                                    const p = td.children[0];
-                                    if (p.children.length !== 0 && p.children[0].nodeName === 'FONT') {
-                                        str = p.children[0].textContent.trim();
-                                    } else {
-                                        str = p.textContent.trim();
-                                    }
-                                } else {
-                                    str = td.textContent.trim();
-                                }
-                                str = str.replaceAll('\n', '');
-                                str = str.replaceAll(/\s\s+/g, ' ');
-                                changes.push({ y: y, x: x, value: str });
-                                x++;
-                            }
-                        }
-                        y++;
-                    }
-                }
-            }
-        }
-
-        if (props.onChange) {
-            props.onChange(changes);
-        }
-        let pasteX2 = x - 1;
-        let pasteY2 = y - 1;
-        changeSelection(pasteLocX, pasteLocY, pasteX2, pasteY2, false);
-    };
-
-    const parsePastedText = (text: string) => {
-        let pasteLocX = -1;
-        let pasteLocY = -1;
-        if (selection.x1 !== -1 && selection.x2 === -1) {
-            pasteLocX = selection.x1;
-        }
-        if (selection.x1 !== -1 && selection.x2 !== -1) {
-            pasteLocX = Math.min(selection.x1, selection.x2);
-        }
-        if (selection.x1 === -1 && selection.x2 === -1 && selection.y1 !== -1 && selection.y2 !== -1) {
-            pasteLocX = 0;
-        }
-
-        if (selection.y1 !== -1 && selection.y2 === -1) {
-            pasteLocY = selection.y1;
-        }
-        if (selection.y1 !== -1 && selection.y2 !== -1) {
-            pasteLocY = Math.min(selection.y1, selection.y2);
-        }
-        if (selection.y1 === -1 && selection.y2 === -1 && selection.x2 !== -1 && selection.x2 !== -1) {
-            pasteLocY = 0;
-        }
-
-        if (pasteLocX === -1 || pasteLocY === -1) {
-            return;
-        }
-
-        const rows = text.split(/\r?\n/);
-        let pasteX2 = pasteLocX;
-        let pasteY2 = pasteLocY + rows.length - 1;
-        const changes = [];
-        for (let y = 0; y < rows.length; y++) {
-            const cols = rows[y].split('\t');
-
-            if (pasteLocX + cols.length - 1 > pasteX2) {
-                pasteX2 = pasteLocX + cols.length - 1;
-            }
-            for (let x = 0; x < cols.length; x++) {
-                changes.push({ y: pasteLocY + y, x: pasteLocX + x, value: cols[x] });
-            }
-        }
-
-        if (props.onChange) {
-            props.onChange(changes);
-        }
-        changeSelection(pasteLocX, pasteLocY, pasteX2, pasteY2, false);
-    };
-
-    const setCopyPasteText = () => {
-        if (selection.x1 === -1 && selection.y1 === -1 && selection.x2 === -1 && selection.y2 === -1) {
-            return;
-        }
-
-        let dy1 = selection.y1;
-        let dy2 = selection.y2;
-        if (dy1 > dy2) {
-            dy1 = selection.y2;
-            dy2 = selection.y1;
-        }
-
-        let dx1 = selection.x1;
-        let dx2 = selection.x2;
-        if (dx1 > dx2) {
-            dx1 = selection.x2;
-            dx2 = selection.x1;
-        }
-
-        if (dx1 === -1 && dx2 === -1) {
-            const max = findApproxMaxEditDataIndex(editData);
-            dx1 = 0;
-            dx2 = max.x;
-        }
-        if (dy1 === -1 && dy2 === -1) {
-            const max = findApproxMaxEditDataIndex(editData);
-            dy1 = 0;
-            dy2 = max.y;
-        }
-
-        let cptext = '';
-        let cptextTemp = '';
-        for (let y = dy1; y <= dy2; y++) {
-            let nonEmpty = false;
-            for (let x = dx1; x <= dx2; x++) {
-                const value = editData(x, y);
-                if (value !== null && value !== undefined) {
-                    cptextTemp += value;
-                    nonEmpty = true;
-                }
-                if (x !== dx2) {
-                    cptextTemp += '\t';
-                }
-            }
-            if (y !== dy2) {
-                cptextTemp += '\n';
-            }
-            if (nonEmpty) {
-                cptext += cptextTemp;
-                cptextTemp = '';
-            }
-        }
-        if (copyPasteTextAreaRef.current) {
-            copyPasteTextAreaRef.current.value = cptext;
-        }
-    };
-
-    const commitEditingCell = (value?: string) => {
-        if (props.onChange) {
-            props.onChange([{ x: editCell.x, y: editCell.y, value: value !== undefined ? value : editValue }]);
-        }
-
-        setEditCell({ x: -1, y: -1 });
-        setEditKey('');
-    };
-
-    const startEditingCell = (editCell: CellCoordinate) => {
-        if (cellReadOnly(editCell.x, editCell.y)) {
-            return;
-        }
-
-        const editDataValue = editData(editCell.x, editCell.y);
-        let val = '';
-        if (editDataValue !== null && editDataValue !== undefined) {
-            val = editDataValue;
-        }
-        const editDataKey = editKeys ? editKeys(editCell.x, editCell.y) : '';
-        setEditCell(editCell);
-        setEditKey(editDataKey);
-        setEditValue(val);
-        setShiftKeyDown(false);
-    };
-
-    const onScroll = (e: UIEvent) => {
-        if (!e.target || !(e.target instanceof Element)) {
-            return;
-        }
-        const absX = e.target.scrollLeft;
-        const absY = e.target.scrollTop;
-
-        const cellX = Math.floor(absX / scrollSpeed);
-        const cellY = Math.floor(absY / scrollSpeed);
-        if (cellX !== dataOffset.x || cellY !== dataOffset.y) {
-            setDataOffset({ x: cellX, y: cellY });
-        }
-
-        let newMaxScroll = { ...maxScroll };
-        if (maxScroll.x / (absX + 0.5) < 1) {
-            newMaxScroll.x *= 1.5;
-        }
-        if (maxScroll.y / (absY + 0.5) < 1) {
-            newMaxScroll.y *= 1.5;
-        }
-        if (newMaxScroll.x !== maxScroll.x || maxScroll.y !== newMaxScroll.y) {
-            setMaxScroll({ ...newMaxScroll });
-        }
-    };
-
-    const onMouseLeave = () => {
-        window.document.body.style.cursor = 'auto';
-    };
-
-    const onMouseDown = (e: MouseEvent) => {
-        if (e.button !== 0) {
-            return;
-        }
-        if (!e.target || !(e.target instanceof Element)) {
-            return;
-        }
-
-        // cancel selection
-        setSelectionInProgress(false);
-
-        const rect = e.target.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-
-        if (x > canvasWidth || y > canvasHeight) {
-            return;
-        }
-
-        const hitTargetKeyX = Math.floor(x / xBinSize);
-        const hitTargetKeyY = Math.floor(y / yBinSize);
-
-        if (hitMap[hitTargetKeyX] && hitMap[hitTargetKeyX][hitTargetKeyY]) {
-            for (const hitTarget of hitMap[hitTargetKeyX][hitTargetKeyY]) {
-                if (
-                    hitTarget.x <= x &&
-                    x <= hitTarget.x + hitTarget.w &&
-                    hitTarget.y <= y &&
-                    y <= hitTarget.y + hitTarget.h
-                ) {
-                    setButtonClickMouseDownCoordinates({ x, y, hitTarget });
-                    return;
-                }
-            }
-        }
-
-        if (!sheetStyle.hideColumnHeaders && y < sheetStyle.columnHeaderHeight) {
-            for (let colIdx = 0; colIdx < columnSizes.index.length; colIdx++) {
-                const start = columnSizes.start[colIdx];
-                const end = columnSizes.end[colIdx];
-                const index = columnSizes.index[colIdx];
-                if (
-                    Math.abs(start - x) < resizeColumnRowMouseThreshold ||
-                    Math.abs(end - x) < resizeColumnRowMouseThreshold
-                ) {
-                    window.document.body.style.cursor = 'col-resize';
-                    const indices: number[] = [];
-                    if (selection.x1 !== -1 && selection.x2 !== -1 && selection.y1 === -1 && selection.y2 === -1) {
-                        const min = Math.min(selection.x1, selection.x2);
-                        const max = Math.max(selection.x1, selection.x2);
-                        for (let i = min; i <= max; i++) {
-                            indices.push(i);
-                        }
-                    }
-                    if (indices.length === 0) {
-                        indices.push(index);
-                    }
-                    setColumnResize({
-                        startX: end,
-                        oldWidth: cellWidth(index),
-                        colIndices: indices,
-                    });
-                    return;
-                }
-            }
-        }
-        if (!sheetStyle.hideRowHeaders && x < sheetStyle.rowHeaderWidth) {
-            for (let rowIdx = 0; rowIdx < rowSizes.index.length; rowIdx++) {
-                const start = rowSizes.start[rowIdx];
-                const end = rowSizes.end[rowIdx];
-                const index = rowSizes.index[rowIdx];
-                if (
-                    Math.abs(start - y) < resizeColumnRowMouseThreshold ||
-                    Math.abs(end - y) < resizeColumnRowMouseThreshold
-                ) {
-                    window.document.body.style.cursor = 'row-resize';
-                    const indices: number[] = [];
-                    if (selection.x1 === -1 && selection.x2 === -1 && selection.y1 !== -1 && selection.y2 !== -1) {
-                        const min = Math.min(selection.y1, selection.y2);
-                        const max = Math.max(selection.y1, selection.y2);
-                        for (let i = min; i <= max; i++) {
-                            indices.push(i);
-                        }
-                    }
-                    if (indices.length === 0) {
-                        indices.push(index);
-                    }
-                    setRowResize({
-                        startY: end,
-                        oldHeight: cellHeight(index),
-                        rowIndices: indices,
-                    });
-                    return;
-                }
-            }
-        }
-
-        // knob drag mode
-        if (Math.abs(x - knobCoordinates.x) < knobSize && Math.abs(y - knobCoordinates.y) < knobSize) {
-            setKnobDragInProgress(true);
-            setKnobArea({ x1: selection.x1, y1: selection.y1, x2: selection.x2, y2: selection.y2 });
-            return;
-        }
-
-        const sel2 = absCoordianteToCell(x, y, rowSizes, columnSizes);
-        const sel1 = shiftKeyDown ? { x: selection.x1, y: selection.y1 } : { ...sel2 };
-
-        if (editMode) {
-            if (!props.dontCommitEditOnSelectionChange) {
-                commitEditingCell();
-            }
-        }
-
-        let scrollToP2 = true;
-
-        if (!sheetStyle.hideRowHeaders && x < sheetStyle.rowHeaderWidth) {
-            scrollToP2 = false;
-            setRowSelectionInProgress(true);
-            sel1.x = -1;
-            sel2.x = -1;
-        } else {
-            setRowSelectionInProgress(false);
-        }
-
-        if (!sheetStyle.hideColumnHeaders && y < sheetStyle.columnHeaderHeight) {
-            scrollToP2 = false;
-            setColumnSelectionInProgress(true);
-            sel1.y = -1;
-            sel2.y = -1;
-        } else {
-            setColumnSelectionInProgress(false);
-        }
-
-        setSelectionInProgress(true);
-        changeSelection(sel1.x, sel1.y, sel2.x, sel2.y, scrollToP2);
-        if (!props.dontCommitEditOnSelectionChange) {
-            setEditCell({ x: -1, y: -1 });
-            setEditKey('');
-        }
-    };
-
-    const onMouseUp = (e: MouseEvent) => {
-        if (knobDragInProgress) {
-            let sx1 = selection.x1;
-            let sx2 = selection.x2;
-            if (selection.x1 > selection.x2) {
-                sx1 = selection.x2;
-                sx2 = selection.x1;
-            }
-            let sy1 = selection.y1;
-            let sy2 = selection.y2;
-            if (selection.y1 > selection.y2) {
-                sy1 = selection.y2;
-                sy2 = selection.y1;
-            }
-            let kx1 = knobArea.x1;
-            let kx2 = knobArea.x2;
-            if (knobArea.x1 > knobArea.x2) {
-                kx1 = knobArea.x2;
-                kx2 = knobArea.x1;
-            }
-            let ky1 = knobArea.y1;
-            let ky2 = knobArea.y2;
-            if (knobArea.y1 > knobArea.y2) {
-                ky1 = knobArea.y2;
-                ky2 = knobArea.y1;
-            }
-
-            let fx1 = kx1;
-            let fy1 = ky1;
-            let fx2 = kx2;
-            let fy2 = ky2;
-
-            const changes: Array<Change> = [];
-
-            if (fx2 - fx1 === sx2 - sx1) {
-                // vertical
-                if (fy1 === sy1) {
-                    fy1 = sy2 + 1;
-                } else {
-                    fy2 = sy1 - 1;
-                }
-                if (fx1 === -1 && fx2 === -1) {
-                    const max = findApproxMaxEditDataIndex(editData);
-                    fx1 = 0;
-                    fx2 = max.x;
-                }
-                let srcY = sy1;
-                for (let y = fy1; y <= fy2; y++) {
-                    for (let x = fx1; x <= fx2; x++) {
-                        const value = sourceData(x, srcY);
-                        changes.push({ x: x, y: y, value: value, source: { x: x, y: srcY } });
-                    }
-                    srcY = srcY + 1;
-                    if (srcY > sy2) {
-                        srcY = sy1;
-                    }
-                }
-            } else {
-                // horizontal
-                if (fx1 === sx1) {
-                    fx1 = sx2 + 1;
-                } else {
-                    fx2 = sx1 - 1;
-                }
-                if (fy1 === -1 && fy2 === -1) {
-                    const max = findApproxMaxEditDataIndex(editData);
-                    fy1 = 0;
-                    fy2 = max.y;
-                }
-                let srcX = sx1;
-                for (let x = fx1; x <= fx2; x++) {
-                    for (let y = fy1; y <= fy2; y++) {
-                        const value = sourceData(srcX, y);
-                        changes.push({ x: x, y: y, value: value, source: { x: srcX, y: y } });
-                    }
-                    srcX = srcX + 1;
-                    if (srcX > sx2) {
-                        srcX = sx1;
-                    }
-                }
-            }
-
-            if (props.onChange) {
-                props.onChange(changes);
-            }
-
-            changeSelection(knobArea.x1, knobArea.y1, knobArea.x2, knobArea.y2);
-        }
-        setSelectionInProgress(false);
-        setRowSelectionInProgress(false);
-        setColumnSelectionInProgress(false);
-        setKnobDragInProgress(false);
-        setColumnResize(null);
-        setRowResize(null);
-
-        if (
-            buttonClickMouseDownCoordinates.x !== -1 &&
-            buttonClickMouseDownCoordinates.y !== -1 &&
-            buttonClickMouseDownCoordinates.hitTarget !== null
-        ) {
-            if (!e.target || !(e.target instanceof Element)) {
-                return;
-            }
-            const rect = e.target.getBoundingClientRect();
-            const x = e.clientX - rect.left;
-            const y = e.clientY - rect.top;
-            const hitTarget = buttonClickMouseDownCoordinates.hitTarget;
-            if (
-                hitTarget.x <= x &&
-                x <= hitTarget.x + hitTarget.w &&
-                hitTarget.y <= y &&
-                y <= hitTarget.y + hitTarget.h
-            ) {
-                hitTarget.onClick(e);
-            }
-            setButtonClickMouseDownCoordinates({ x: -1, y: -1, hitTarget: null });
-        }
-    };
-
-    useEffect(() => {
-        window.addEventListener('mouseup', onMouseUp as any);
-        return () => {
-            window.removeEventListener('mouseup', onMouseUp as any);
-        };
-    });
-
-    const onMouseMove = (e: MouseEvent) => {
-        if (!e.target || !(e.target instanceof Element)) {
-            return;
-        }
-        const rect = e.target.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-
-        window.document.body.style.cursor = 'auto';
-
-        const hitTargetKeyX = Math.floor(x / xBinSize);
-        const hitTargetKeyY = Math.floor(y / yBinSize);
-
-        if (hitMap[hitTargetKeyX] && hitMap[hitTargetKeyX][hitTargetKeyY]) {
-            for (const hitTarget of hitMap[hitTargetKeyX][hitTargetKeyY]) {
-                if (
-                    hitTarget.x <= x &&
-                    x <= hitTarget.x + hitTarget.w &&
-                    hitTarget.y <= y &&
-                    y <= hitTarget.y + hitTarget.h
-                ) {
-                    window.document.body.style.cursor = 'pointer';
-                }
-            }
-        }
-
-        if (!sheetStyle.hideColumnHeaders && props.onCellWidthChange && y < sheetStyle.columnHeaderHeight) {
-            let xx = sheetStyle.rowHeaderWidth;
-            for (const col of columnSizes.index) {
-                if (Math.abs(xx - x) < resizeColumnRowMouseThreshold) {
-                    window.document.body.style.cursor = 'col-resize';
-                    break;
-                }
-                xx += cellWidth(col);
-            }
-        }
-
-        if (!sheetStyle.hideRowHeaders && props.onCellHeightChange && x < sheetStyle.rowHeaderWidth) {
-            let yy = sheetStyle.columnHeaderHeight;
-            for (const row of rowSizes.index) {
-                if (Math.abs(yy - y) < resizeColumnRowMouseThreshold) {
-                    window.document.body.style.cursor = 'row-resize';
-                    break;
-                }
-                yy += cellHeight(row);
-            }
-        }
-
-        if (Math.abs(x - knobCoordinates.x) < knobSize && Math.abs(y - knobCoordinates.y) < knobSize) {
-            window.document.body.style.cursor = 'crosshair';
-        }
-
-        if (columnResize) {
-            if (props.onCellWidthChange) {
-                const newWidth = Math.max(columnResize.oldWidth + x - columnResize.startX, minimumColumnWidth);
-                props.onCellWidthChange(columnResize.colIndices, newWidth);
-            }
-            return;
-        }
-
-        if (rowResize) {
-            if (props.onCellHeightChange) {
-                const newHeight = Math.max(rowResize.oldHeight + y - rowResize.startY, minimumRowHeight);
-                props.onCellHeightChange(rowResize.rowIndices, newHeight);
-            }
-            return;
-        }
-
-        if (selectionInProgress) {
-            const sel2 = absCoordianteToCell(x, y, rowSizes, columnSizes);
-            if (rowSelectionInProgress) {
-                changeSelection(-1, selection.y1, -1, sel2.y, false);
-            } else if (columnSelectionInProgress) {
-                changeSelection(selection.x1, -1, sel2.x, -1, false);
-            } else {
-                changeSelection(selection.x1, selection.y1, sel2.x, sel2.y);
-            }
-        }
-
-        if (knobDragInProgress) {
-            window.document.body.style.cursor = 'crosshair';
-            const cell = absCoordianteToCell(x, y, rowSizes, columnSizes);
-
-            let x1 = selection.x1;
-            let y1 = selection.y1;
-            let x2 = selection.x2;
-            let y2 = selection.y2;
-            if (x1 > x2) {
-                x1 = selection.x2;
-                x2 = selection.x1;
-            }
-            if (y1 > y2) {
-                y1 = selection.y2;
-                y2 = selection.y1;
-            }
-
-            // check if vertical or horizontal
-            let xCellDiff = 0; // zero or less
-            if (cell.x < x1) xCellDiff = cell.x - x1;
-            if (cell.x > x2) xCellDiff = x2 - cell.x;
-            let yCellDiff = 0; // zero or less
-            if (cell.y < y1) yCellDiff = cell.y - y1;
-            if (cell.y > y2) yCellDiff = y2 - cell.y;
-
-            if ((x1 === -1 && x2 === -1) || xCellDiff > yCellDiff) {
-                if (cell.y < y1) {
-                    y1 = cell.y;
-                } else {
-                    y2 = cell.y;
-                }
-            } else {
-                if (cell.x < x1) {
-                    x1 = cell.x;
-                } else {
-                    x2 = cell.x;
-                }
-            }
-            setKnobArea({ x1: x1, y1: y1, x2: x2, y2: y2 });
-        }
-    };
-
-    const onDoubleClick = (e: MouseEvent) => {
-        e.preventDefault();
-        if (!e.target || !(e.target instanceof Element) || shiftKeyDown) {
-            return;
-        }
-
-        const rect = e.target.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-
-        // check if we clicked on a button and don't start editing if we did
-        const hitTargetKeyX = Math.floor(x / xBinSize);
-        const hitTargetKeyY = Math.floor(y / yBinSize);
-
-        if (hitMap[hitTargetKeyX] && hitMap[hitTargetKeyX][hitTargetKeyY]) {
-            for (const hitTarget of hitMap[hitTargetKeyX][hitTargetKeyY]) {
-                if (
-                    hitTarget.x <= x &&
-                    x <= hitTarget.x + hitTarget.w &&
-                    hitTarget.y <= y &&
-                    y <= hitTarget.y + hitTarget.h
-                ) {
-                    return;
-                }
-            }
-        }
-        const editCell = absCoordianteToCell(x, y, rowSizes, columnSizes);
-        setArrowKeyCommitMode(false);
-        if (editMode) {
-            commitEditingCell();
-        }
-        startEditingCell(editCell);
-    };
-
     const onKeyDown = (e: KeyboardEvent) => {
+        console.log('onKeyDown', e.key, e)
         if (e.key === 'Escape') {
-            setEditCell({ x: -1, y: -1 });
-            setEditKey('');
+            setEditCell(NO_CELL);
             return;
         }
-        if (e.key === 'Enter') {
-            commitEditingCell();
-            changeSelection(selection.x1, selection.y1 + 1, selection.x1, selection.y1 + 1);
-        }
-        if (e.key === 'Tab') {
+
+        const direction = (e.key === 'Enter' || e.key === 'TAB')
+            ? 'right'
+            : arrowKeyCommitMode
+                ? ARROW_KEYS[e.key]
+                : null;
+
+        if (direction) {
             e.preventDefault();
+            const step = getDirectionStep(direction);
+            const head = maxXY(addXY(editCell, step), ORIGIN);
             commitEditingCell();
-            changeSelection(selection.x1 + 1, selection.y1, selection.x1 + 1, selection.y1);
-        }
-        if (arrowKeyCommitMode && ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-            e.preventDefault();
-            commitEditingCell();
-            let x1 = selection.x1;
-            let y1 = selection.y1;
-            let x2 = selection.x1;
-            let y2 = selection.y1;
-            if (e.key === 'ArrowRight') {
-                x1 = selection.x1 + 1;
-                x2 = selection.x1 + 1;
-            } else if (e.key === 'ArrowLeft') {
-                x1 = selection.x1 - 1;
-                x2 = selection.x1 - 1;
-            } else if (e.key === 'ArrowUp') {
-                y1 = selection.y1 - 1;
-                y2 = selection.y1 - 1;
-            } else if (e.key === 'ArrowDown') {
-                y1 = selection.y1 + 1;
-                y2 = selection.y1 + 1;
-            }
-            changeSelection(x1, y1, x2, y2);
+            changeSelection([head, head]);
         }
     };
 
     const onGridKeyDown = (e: KeyboardEvent) => {
-        if (editMode && arrowKeyCommitMode && ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        console.log('onGridKeydown', e.key, e)
+        if (editMode && arrowKeyCommitMode && (e.key in ARROW_KEYS)) {
             commitEditingCell();
-            return;
-        }
-
-        if (e.key === 'Shift') {
-            setShiftKeyDown(true);
             return;
         }
 
@@ -2175,26 +382,16 @@ function Sheet(props: SheetProps) {
         }
 
         if (e.key === 'Backspace' || e.key === 'Delete') {
-            let x1 = selection.x1;
-            let y1 = selection.y1;
-            let x2 = selection.x2;
-            let y2 = selection.y2;
-            if (x1 > x2) {
-                x1 = selection.x2;
-                x2 = selection.x1;
-            }
-            if (y1 > y2) {
-                y1 = selection.y2;
-                y2 = selection.y1;
-            }
-            if (x1 === -1 && x2 === -1 && y1 !== -1 && y2 !== -1) {
+            let [[x1, y1], [x2, y2]] = normalizeSelection(selection);
+            if (isRowSelection(selection)) {
                 x1 = 0;
-                x2 = maxSearchableRowOrCol;
+                x2 = MAX_SEARCHABLE_INDEX;
             }
-            if (x1 !== -1 && x2 !== -1 && y1 === -1 && y2 === -1) {
+            if (isColumnSelection(selection)) {
                 y1 = 0;
-                y2 = maxSearchableRowOrCol;
+                y2 = MAX_SEARCHABLE_INDEX;
             }
+
             const changes: Change[] = [];
             for (let y = y1; y <= y2; y++) {
                 for (let x = x1; x <= x2; x++) {
@@ -2208,7 +405,7 @@ function Sheet(props: SheetProps) {
         }
 
         // nothing selected
-        if (selection.x1 === -1 || selection.x2 === -1 || selection.y1 === -1 || selection.y2 === -1) {
+        if (isEmptySelection(selection)) {
             return;
         }
 
@@ -2221,143 +418,83 @@ function Sheet(props: SheetProps) {
             e.key === '.' ||
             e.key === ','
         ) {
-            if (cellReadOnly(selection.x1, selection.y1)) {
+            const [cell] = selection;
+            const [cellX, cellY] = cell;
+            if (cellReadOnly(cellX, cellY)) {
                 e.preventDefault(); // so we dont get keystrokes inside the text area
                 return;
             }
 
-            startEditingCell({ x: selection.x1, y: selection.y1 });
-            setArrowKeyCommitMode(e.key !== 'Enter');
+            startEditingCell(cell, e.key !== 'Enter');
             return;
         }
 
-        if (['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-            let sel1 = { x: selection.x1, y: selection.y1 };
-            let sel2 = { x: selection.x2, y: selection.y2 };
+        if (e.key in ARROW_KEYS) {
+            let [anchor, head] = selection;
 
-            let incr = { x: 0, y: 0 };
-            let direction: 'up' | 'down' | 'left' | 'right' = 'right';
-            if (e.key === 'ArrowRight' || e.key === 'Tab') {
-                incr.x = 1;
-                direction = 'right';
-            } else if (e.key === 'ArrowLeft') {
-                incr.x = -1;
-                direction = 'left';
-            } else if (e.key === 'ArrowUp') {
-                incr.y = -1;
-                direction = 'up';
-            } else if (e.key === 'ArrowDown') {
-                incr.y = 1;
-                direction = 'down';
-            }
+            const direction = ARROW_KEYS[e.key];
+            const step = getDirectionStep(direction);
 
             if (e.metaKey || e.ctrlKey) {
-                const val = findInDisplayData(displayData, sel2, direction);
-                incr.x = val.x - sel2.x;
-                incr.y = val.y - sel2.y;
+                head = findInDisplayData(displayData, head, direction);
             }
-
-            sel2.x += incr.x;
-            sel2.y += incr.y;
-
-            if (sel2.x < 0) {
-                sel2.x = 0;
-            }
-            if (sel2.y < 0) {
-                sel2.y = 0;
+            else {
+                head = maxXY(addXY(head, step), ORIGIN);
             }
             if (!e.shiftKey) {
-                sel1 = { ...sel2 };
+                anchor = head;
             }
-            changeSelection(sel1.x, sel1.y, sel2.x, sel2.y);
+            changeSelection([anchor, head]);
             return;
         }
+
         e.preventDefault();
     };
 
-    const onGridKeyUp = (e: KeyboardEvent) => {
-        setShiftKeyDown(e.shiftKey);
-    };
+    const editKey = editKeys ? editKeys(...editCell) : '';
+    const [lastEditKey, setLastEditKey] = useState(editKey);
+    if (lastEditKey !== editKey) {
+        setLastEditKey(editKey);
+        setEditCell(NO_CELL);
+    }
 
-    const onContextMenu = (e: MouseEvent) => {
-        if (!e.target || !(e.target instanceof Element)) {
-            return;
-        }
-
-        const rect = e.target.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-        const cell = absCoordianteToCell(x, y, rowSizes, columnSizes);
-        const cellX = cell.x;
-        const cellY = cell.y;
-        let { x1, x2, y1, y2 } = selection;
-        if (x1 > x2) [x1, x2] = [x2, x1];
-        if (y1 > y2) [y1, y2] = [y2, y1];
-
-        if (!(y > sheetStyle.columnHeaderHeight && x > sheetStyle.rowHeaderWidth)) {
-            return;
-        }
-        //if click is not inside of selection, select the right clicked cell
-        if (!(cellX >= x1 && cellX <= x2) || !(cellY >= y1 && cellY <= y2)) {
-            changeSelection(cellX, cellY, cellX, cellY);
-        }
-
-        onMouseMove(e);
-        const ev: SheetMouseEvent = {
-            ...e,
-            cellX,
-            cellY,
-        };
-        props.onRightClick?.(ev);
-    };
-
-    const editMode = editCell.x !== -1 && editCell.y !== -1;
-    let editTextPosition = { x: 0, y: 0 };
+    let editTextPosition = ORIGIN;
     let editTextWidth = 0;
     let editTextHeight = 0;
     let editTextTextAlign: 'right' | 'left' | 'center' = 'right';
     if (editMode) {
-        editTextPosition = cellToAbsCoordinate(
-            editCell.x,
-            editCell.y,
-            rowSizes,
-            columnSizes,
-            dataOffset,
-            cellWidth,
-            cellHeight,
-            sheetStyle
-        );
-        const style = cellStyle(editCell.x, editCell.y);
-        // add 1 so it doesnt cover the selection border
-        editTextPosition.x += 1;
-        editTextPosition.y += 1;
-        editTextWidth = cellWidth(editCell.x) - 2;
-        editTextHeight = cellHeight(editCell.y) - 2;
-        editTextTextAlign = style.textAlign || defaultCellStyle.textAlign || 'left';
+        const style = cellStyle(...editCell);
+        editTextPosition = cellToPixel(editCell);
+        editTextPosition = addXY(editTextPosition, ONE_ONE);
+        editTextWidth = cellWidth(editCellX) - 2;
+        editTextHeight = cellHeight(editCellY) - 2;
+        editTextTextAlign = style.textAlign || DEFAULT_CELL_STYLE.textAlign || 'left';
     }
 
+    const [textX, textY] = editTextPosition;
     const inputProps = {
         value: editValue,
         autoFocus: true,
         onKeyDown: onKeyDown,
         style: {
             position: 'absolute',
-            top: editTextPosition.y,
-            left: editTextPosition.x,
+            left: textX,
+            top: textY,
+            padding: '0px 4px',
             width: editTextWidth,
             height: editTextHeight,
             outline: 'none',
             border: 'none',
             textAlign: editTextTextAlign,
             color: 'black',
-            fontSize: defaultCellStyle.fontSize,
+            fontSize: DEFAULT_CELL_STYLE.fontSize,
             fontFamily: 'sans-serif',
         } as InputStyle,
     };
 
     const input = props.inputComponent?.(
-        editCell.x,
-        editCell.y,
+        editCellX,
+        editCellY,
         { ...inputProps, onChange: setEditValue } as SheetInputProps,
         commitEditingCell
     );
@@ -2390,11 +527,7 @@ function Sheet(props: SheetProps) {
             <canvas style={canvasStyles} ref={canvasRef} />
             <div
                 ref={overlayRef}
-                onDoubleClick={onDoubleClick}
-                onMouseDown={onMouseDown}
-                onMouseMove={onMouseMove}
-                onMouseLeave={onMouseLeave}
-                onContextMenu={onContextMenu}
+                {...mouseHandlers}
                 onScroll={onScroll}
                 className={overlayDivClassName}
                 style={overlayDivStyles}
@@ -2405,7 +538,7 @@ function Sheet(props: SheetProps) {
                         left: 0,
                         top: 0,
                         width: 1,
-                        height: maxScroll.y + 2000,
+                        height: maxScrollY + 2000,
                         backgroundColor: 'rgba(0,0,0,0.0)',
                     }}
                 ></div>
@@ -2414,7 +547,7 @@ function Sheet(props: SheetProps) {
                         position: 'absolute',
                         left: 0,
                         top: 0,
-                        width: maxScroll.x + 5000,
+                        width: maxScrollX + 5000,
                         height: 1,
                         backgroundColor: 'rgba(0,0,0,0.0)',
                     }}
@@ -2422,7 +555,7 @@ function Sheet(props: SheetProps) {
             </div>
             <textarea
                 style={{ position: 'absolute', top: 0, left: 0, width: 1, height: 1, opacity: 0.01 }}
-                ref={copyPasteTextAreaRef}
+                ref={textAreaRef}
                 autoComplete="off"
                 autoCorrect="off"
                 autoCapitalize="off"
@@ -2430,7 +563,6 @@ function Sheet(props: SheetProps) {
                 onFocus={(e) => e.target.select()}
                 tabIndex={0}
                 onKeyDown={onGridKeyDown}
-                onKeyUp={onGridKeyUp}
             ></textarea>
             {editMode &&
                 (input !== undefined ? (
@@ -2445,6 +577,6 @@ function Sheet(props: SheetProps) {
                 ))}
         </div>
     );
-}
+});
 
 export default Sheet;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -466,8 +466,8 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
         const style = cellStyle(...editCell);
         editTextPosition = cellToPixel(editCell);
         editTextPosition = addXY(editTextPosition, ONE_ONE);
-        editTextWidth = cellWidth(editCellX) - 2;
-        editTextHeight = cellHeight(editCellY) - 2;
+        editTextWidth = cellWidth(editCellX) - 3;
+        editTextHeight = cellHeight(editCellY) - 3;
         editTextTextAlign = style.textAlign || DEFAULT_CELL_STYLE.textAlign || 'left';
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -392,6 +392,8 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
 
         // copy
         if ((e.metaKey || e.ctrlKey) && String.fromCharCode(e.which).toLowerCase() === 'c') {
+            const {current: textArea} = textAreaRef;
+            textArea?.select();
             return;
         }
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,0 +1,338 @@
+import { XY, CellLayout, VisibleLayout, LayoutCache } from './types';
+import { seq } from './util';
+import { ORIGIN } from './constants';
+
+const INITIAL_SIZE = 256;
+
+// Local cell layout (virtualized with frozen columns/rows)
+//
+// - converts cell indices to (x, y) canvas pixels for any cell, including off-screen
+// - maps (x, y) canvas pixels back to cell index for any visible cell
+// - can also generate absolute, unscrolled offsets relative to (0,0) to drive scrolling
+// - generates list of visible cols/rows in view
+//
+// Note that adjacent column indices are not necessarily adjacent, i.e. end of [i] != start of [i + 1].
+export const makeCellLayout = (
+    freeze: XY,
+    indent: XY,
+    offset: XY,
+
+    columns: LayoutCache,
+    rows: LayoutCache,
+): CellLayout => {
+    const [freezeX, freezeY] = freeze;
+    const [indentX, indentY] = indent;
+    const [offsetX, offsetY] = offset;
+
+    const getIndentX = () => indentX;
+    const getIndentY = () => indentY;
+
+    // Origin for cell, frozen or relative
+    const getBaseOriginFor = (index: number, freeze: number, offset: number) => {
+        return index < freeze ? 0 : offset;
+    };
+    
+    // Get visible pixel x of cell
+    const columnToPixel = (column: number, anchor: number = 0): number => {
+        const base = getBaseOriginFor(column, freezeX, offsetX);
+        const relative = columns.getStart(column) - columns.getStart(base);
+        const size = column < 0 ? indentX : columns.getSize(column);
+
+        return column < 0 ? 0 : indentX + relative + anchor * size;
+    };
+
+    // Get visible pixel y of cell
+    const rowToPixel = (row: number, anchor: number = 0): number => {
+        const base = getBaseOriginFor(row, freezeY, offsetY);
+        const relative = rows.getStart(row) - rows.getStart(base);
+        const size = row < 0 ? indentY : rows.getSize(row);
+
+        return row < 0 ? 0 : indentY + relative + anchor * size;
+    };
+
+    // Get visible pixel position of cell, offset with anchor [0..1, 0..1]
+    const cellToPixel = (cell: XY, anchor: XY = ORIGIN): XY => {
+        const [cellX, cellY] = cell;
+        const [anchorX, anchorY] = anchor;
+        return [
+            columnToPixel(cellX, anchorX),
+            rowToPixel(cellY, anchorY),
+        ];
+    };
+
+    // Get absolute / unscrolled pixel x of cell
+    const columnToAbsolute = (column: number, anchorX: number = 0): number => {
+        const relative = columns.getStart(column);
+        const size = column < 0 ? 0 : columns.getSize(column);
+
+        return relative + anchorX * size;
+    };
+
+    // Get absolute / unscrolled pixel y of cell
+    const rowToAbsolute = (row: number, anchorY: number = 0): number => {
+        const relative = rows.getStart(row);
+        const size = row < 0 ? 0 : rows.getSize(row);
+
+        return relative + anchorY * size;
+    };
+
+    // Get absolute / unscrolled pixel position of cell, offset with anchor [0..1, 0..1]
+    const cellToAbsolute = (cell: XY, anchor: XY = ORIGIN): XY => {
+        const [cellX, cellY] = cell;
+        const [anchorX, anchorY] = anchor;
+        return [
+            columnToAbsolute(cellX, anchorX),
+            rowToAbsolute(cellY, anchorY),
+        ];
+    };
+
+    // Lookup pixel X or Y in cell layout
+    const pixelToIndex = (pixel: number, anchor: number, indent: number, freeze: number, offset: number, layout: LayoutCache) => {
+        const relative = pixel - indent;
+        if (relative < 0) return -1;
+
+        const {getStart, lookupIndex} = layout;
+        const frozen = getStart(freeze);
+        if (relative < frozen) {
+            return lookupIndex(relative, anchor);
+        }
+        else {
+            const base = getStart(offset);
+            return lookupIndex(base + relative, anchor);
+        }
+    };
+
+    // Lookup pixel X or Y in cell layout (helpers)
+    const pixelToColumn = (pixelX: number, anchorX: number = 0) => pixelToIndex(pixelX, anchorX, indentX, freezeX, offsetX, columns);
+    const pixelToRow = (pixelY: number, anchorY: number = 0) => pixelToIndex(pixelY, anchorY, indentY, freezeY, offsetY, rows);
+
+    // Lookup pixel XY in cell layout
+    const pixelToCell = (pixel: XY, anchor: XY = ORIGIN): XY => {
+        const [pixelX, pixelY] = pixel;
+        const [anchorX, anchorY] = anchor;
+        return [
+            pixelToColumn(pixelX, anchorX),
+            pixelToRow(pixelY, anchorY),
+        ];
+    };
+
+    // Lookup absolute / unscrolled pixel X or Y in cell layout
+    const absoluteToIndex = (pixel: number, anchor: number, layout: LayoutCache) => {
+        if (pixel < 0) return -1;
+
+        const {lookupIndex} = layout;
+        return lookupIndex(pixel, anchor);
+    };
+
+    // Lookup absolute / unscrolled X or Y in cell layout (helpers)
+    const absoluteToColumn = (pixelX: number, anchorX: number = 0) => absoluteToIndex(pixelX, anchorX, columns);
+    const absoluteToRow = (pixelY: number, anchorY: number = 0) => absoluteToIndex(pixelY, anchorY, rows);
+
+    // Lookup absolute / unscrolled XY in cell layout
+    const absoluteToCell = (pixel: XY, anchor: XY = ORIGIN): XY => {
+        const [pixelX, pixelY] = pixel;
+        const [anchorX, anchorY] = anchor;
+        return [
+            absoluteToColumn(pixelX, anchorX),
+            absoluteToRow(pixelY, anchorY),
+        ];
+    };
+
+    // Get visible range of columns or rows
+    const getVisibleIndices = (view: number, indent: number, freeze: number, offset: number, layout: LayoutCache) => {
+        const indices = [...seq(freeze)];
+
+        const {getStart} = layout;
+        const relative = view - indent + getStart(offset);
+        for (let i = offset + freeze; getStart(i) <= relative; ++i) {
+            indices.push(i);
+        }
+
+        return indices;
+    };
+
+    // Get visible range for an XY viewport
+    const getVisibleCells = (view: XY): VisibleLayout => {
+        const [viewX, viewY] = view;
+        return {
+            columns: getVisibleIndices(viewX, indentX, freezeX, offsetX, columns),
+            rows: getVisibleIndices(viewY, indentY, freezeY, offsetY, rows),
+        };
+    };
+
+    const getVersion = () => columns.getVersion() + rows.getVersion();
+
+    return {
+        columnToPixel,
+        rowToPixel,
+        cellToPixel,
+
+        columnToAbsolute,
+        rowToAbsolute,
+        cellToAbsolute,
+
+        pixelToColumn,
+        pixelToRow,
+        pixelToCell,
+
+        absoluteToColumn,
+        absoluteToRow,
+        absoluteToCell,
+
+        getVisibleCells,
+        getIndentX,
+        getIndentY,
+
+        getVersion,
+    };
+}
+
+// Offset cache in 1 dimension.
+//
+// Allows O(1) queries of distance between any two points, once warmed up.
+// Can do reverse lookup back to index with binary search, once warmed up.
+//
+// - caches sizer(i), each is only called once
+// - offset[0] = 0
+// - adds up offset[i] = sizer(0) + sizer(1) + ... + sizer(i - 1)
+// - cache can be truncated during resizing ops at split
+// - to replace sizer function, cache must be destroyed
+export const makeLayoutCache = (
+    sizer: (index: number) => number,
+): LayoutCache => {
+    const offsets = makeIntMap(INITIAL_SIZE);
+    const sizes = makeIntMap(INITIAL_SIZE);
+
+    let version = 0;
+    offsets.set(0, 0);
+
+    // Cache size lookup directly
+    const getSize = (i: number): number => {
+        if (i < 0) return 0;
+        if (sizes.has(i)) return sizes.get(i)!;
+
+        const size = sizer(i) || 0;
+        sizes.set(i, size);
+        return size;
+    };
+
+    // Cache offset sum recursively
+    const getOffset = (i: number): number => {
+        if (i < 0) return 0;
+        if (offsets.has(i)) return offsets.get(i)!;
+
+        let j = (offsets.tail() || 0);
+
+        // Use a while loop to avoid stack overflow
+        while (j < i) {
+            const size = getSize(j);
+            const offset = (offsets.get(j) || 0) + size;
+            offsets.set(++j, offset);
+        }
+
+        return offsets.get(i)!;
+    };
+
+    // Boundary points
+    const getStart = (i: number) => getOffset(i);
+    const getEnd = (i: number) => getOffset(i + 1);
+
+    // Reverse lookup from offset to index
+    const lookupIndex = (x: number, anchor: number = 0) => {
+        // Get end of offsets array
+        let last = offsets.tail() || 0;
+
+        // Extend cache if value exceeds current end
+        while (getOffset(last) < x && getSize(last)) last += 64;
+
+        // Do binary search for exact position
+        let start = 0;
+        let end = last;
+        while (start < end) {
+            let mid = start + Math.floor((end - start) / 2) + 1;
+            let value = getOffset(mid) - (anchor ? anchor * getSize(mid - 1) : 0);
+            if (value <= x) start = mid;
+            else end = mid - 1;
+        }
+
+        return start;
+    };
+
+    const clearAfter = (index: number) => {
+        index = Math.max(0, index);
+        offsets.truncate(index);
+        sizes.truncate(index);
+        version++;
+    };
+
+    const setSizer = (s: (index: number) => number) => {
+        sizer = s;
+    };
+    const getVersion = () => version;
+
+    return {getSize, getStart, getEnd, getVersion, lookupIndex, setSizer, clearAfter};
+};
+
+// Fast map<integer, integer> that is mostly filled in from start to end.
+// Elements are only removed by truncating all indices > n.
+const makeIntMap = (initialSize: number = 128) => {
+    let used: Uint8Array;
+    let values: Uint32Array;
+    let last = 0;
+
+    const GROW = 1.2; // 20% growth at a time
+
+    const allocate = (size: number) => {
+        let newUsed = new Uint8Array(size);
+        let newValues = new Uint32Array(size);
+        if (used) copy(used, newUsed);
+        if (values) copy(values, newValues);
+        used = newUsed;
+        values = newValues;
+    };
+    allocate(initialSize);
+
+    const copy = (from: Uint8Array | Uint32Array, to: Uint8Array | Uint32Array) => {
+        let n = Math.min(from.length, to.length);
+        for (let i = 0; i < n; ++i) {
+            to[i] = from[i];
+        }
+    };
+
+    const ensure = (size: number) => {
+        const l = values.length;
+        const grow = Math.round(l * GROW);
+        if (l < size) allocate(Math.max(grow, size));
+    };
+
+    const truncate = (size: number) => {
+        const l = values.length;
+
+        // Do nothing if smaller
+        if (l < size) return;
+
+        // If more than 20% bigger, shrink to exact size
+        const shrink = Math.round(size * GROW);
+        if (l > shrink) allocate(size);
+        // Else zero out tail
+        else for (let i = size; i < l; ++i) used[i] = 0;
+
+        // Track last filled element
+        last = Math.min(last, size);
+        while (last > 0 && !used[last]) last--;
+    };
+
+    const getTail = () => used[last] ? last : null;
+
+    const setValue = (i: number, value: number) => {
+        ensure(i + 1);
+        values[i] = value;
+        used[i] = 1;
+        last = Math.max(last, i);
+    };
+
+    const getValue = (i: number) => used[i] ? values[i] : null;
+    const hasValue = (i: number) => !!used[i];
+
+    return {truncate, set: setValue, get: getValue, has: hasValue, tail: getTail};
+};

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -1,6 +1,6 @@
 import { CellLayout, CellPropertyFunction, Change, Clickable, Rectangle, SheetMouseEvent, SheetStyle, VisibleLayout, XY } from './types';
 import { MouseEvent, PointerEvent, RefObject, useCallback, useMemo, useRef, useState } from 'react';
-import { normalizeSelection, isColumnSelection, isRowSelection, isCellSelection, isMaybeRowSelection, isPointInsideSelection, addXY, maxXY } from './coordinate';
+import { normalizeSelection, isColumnSelection, isRowSelection, isCellSelection, isMaybeRowSelection, isPointInsideSelection, addXY, subXY, maxXY } from './coordinate';
 import { ONE_ONE, ORIGIN, SIZES } from './constants';
 import { findApproxMaxEditDataIndex } from './props';
 import { isInRange } from './util';
@@ -61,13 +61,13 @@ export const useMouse = (
     const knobPosition = useMemo((): XY | null => {
         const [, [maxX, maxY]] = normalizeSelection(selection);
         if (isRowSelection(selection)) {
-            return addXY(cellToPixel([0, maxY], [0, 1]), [SIZES.knobArea * 0.5, 0]);
+            return subXY(addXY(cellToPixel([0, maxY], [0, 1]), [SIZES.knobArea * 0.5, 0]), ONE_ONE);
         }
         if (isColumnSelection(selection)) {
-            return addXY(cellToPixel([maxX, 0], [1, 0]), [0, SIZES.knobArea * 0.5]);
+            return subXY(addXY(cellToPixel([maxX, 0], [1, 0]), [0, SIZES.knobArea * 0.5]), ONE_ONE);
         }
         if (isCellSelection(selection)) {
-            return cellToPixel([maxX, maxY], ONE_ONE);
+            return subXY(cellToPixel([maxX, maxY], ONE_ONE), ONE_ONE);
         }
         return null;
     }, [selection, cellToPixel, version]);

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -1,0 +1,803 @@
+import { CellLayout, CellPropertyFunction, Change, Clickable, Rectangle, SheetMouseEvent, SheetStyle, VisibleLayout, XY } from './types';
+import { MouseEvent, PointerEvent, RefObject, useCallback, useMemo, useRef, useState } from 'react';
+import { normalizeSelection, isColumnSelection, isRowSelection, isCellSelection, isMaybeRowSelection, isPointInsideSelection, addXY, maxXY } from './coordinate';
+import { ONE_ONE, ORIGIN, SIZES } from './constants';
+import { findApproxMaxEditDataIndex } from './props';
+import { isInRange } from './util';
+
+type DragOp = {
+    anchor: number,
+    scroll: number,
+    size: number,
+    indices: number[],
+};
+
+export const useMouse = (
+    hitmapRef: RefObject<Clickable[]>,
+    selection: Rectangle,
+    knobArea: Rectangle | null,
+    editMode: boolean,
+    editData: CellPropertyFunction<string>,
+    sourceData: CellPropertyFunction<string | number | null>,
+    cellLayout: CellLayout,
+    visibleCells: VisibleLayout,
+    sheetStyle: SheetStyle,
+
+    onEdit?: (cell: XY) => void,
+    onCommit?: () => void,
+    onKnobAreaChange?: (knobArea: Rectangle | null) => void,
+    onDragOffsetChange?: (dragOffset: XY | null) => void,
+    onDropTargetChange?: (selection: Rectangle | null) => void,
+    onSelectionChange?: (selection: Rectangle, scrollToHead?: boolean) => void,
+
+    onInvalidateColumn?: (column: number) => void,
+    onInvalidateRow?: (row: number) => void,
+
+    onChange?: (changes: Change[]) => void,
+    onColumnOrderChange?: (indices: number[], order: number) => void,
+    onRowOrderChange?: (indices: number[], order: number) => void,
+    onCellWidthChange?: (indices: number[], value: number) => void,
+    onCellHeightChange?: (indices: number[], value: number) => void,
+    onRightClick?: (e: SheetMouseEvent) => void,
+
+    dontCommitEditOnSelectionChange?: boolean,
+) => {
+    const [hitTarget, setHitTarget] = useState<Clickable | null>(null);
+
+    const [columnResize, setColumnResize] = useState<DragOp | null>(null);
+    const [rowResize, setRowResize] = useState<DragOp | null>(null);
+    const [columnDrag, setColumnDrag] = useState<DragOp | null>(null);
+    const [rowDrag, setRowDrag] = useState<DragOp | null>(null);
+
+    const [draggingKnob, setDraggingKnob] = useState(false);
+    const [draggingSelection, setDraggingSelection] = useState(false);
+    const [draggingRowSelection, setDraggingRowSelection] = useState(false);
+    const [draggingColumnSelection, setDraggingColumnSelection] = useState(false);
+
+    const {hideRowHeaders, hideColumnHeaders} = sheetStyle;
+    const {cellToPixel, getVersion} = cellLayout;
+    const version = getVersion();
+
+    const knobPosition = useMemo((): XY | null => {
+        const [, [maxX, maxY]] = normalizeSelection(selection);
+        if (isRowSelection(selection)) {
+            return addXY(cellToPixel([0, maxY], [0, 1]), [SIZES.knobArea * 0.5, 0]);
+        }
+        if (isColumnSelection(selection)) {
+            return addXY(cellToPixel([maxX, 0], [1, 0]), [0, SIZES.knobArea * 0.5]);
+        }
+        if (isCellSelection(selection)) {
+            return cellToPixel([maxX, maxY], ONE_ONE);
+        }
+        return null;
+    }, [selection, cellToPixel, version]);
+
+    // Pass dragging state into handlers via ref so they don't need to rebind during resizes/drags
+    const refState = {
+        selection,
+        knobArea,
+        editMode,
+        editData,
+        sourceData,
+        cellLayout,
+        visibleCells,
+
+        knobPosition,
+        columnResize,
+        rowResize,
+        columnDrag,
+        rowDrag,
+
+        draggingKnob,
+        draggingSelection,
+        draggingRowSelection,
+        draggingColumnSelection,
+    };
+    const ref = useRef(refState);
+    ref.current = refState;
+
+    // Hit-testing for rendered objects
+    const getMousePosition = useCallback((e: PointerEvent<any> | MouseEvent<any>) => {
+        if (!e.target || !(e.target instanceof Element)) {
+            return null;
+        }
+
+        const rect = e.target.getBoundingClientRect();
+        const xy: XY = [
+            e.clientX - rect.left,
+            e.clientY - rect.top,
+        ];
+        return xy;
+    }, []);
+
+    const getScrollPosition = useCallback((e: PointerEvent<any> | MouseEvent<any>) => {
+        if (!e.target || !(e.target instanceof Element)) {
+            return [0, 0];
+        }
+
+        const {scrollLeft, scrollTop} = e.target as any;
+        const xy: XY = [scrollLeft, scrollTop];
+
+        return xy;
+    }, []);
+
+    const getMouseHit = useCallback((xy: XY) => {
+        const {current: hitmap} = hitmapRef;
+        if (!hitmap) return null;
+
+        for (const object of hitmap) {
+            const {rect} = object;
+            if (isPointInsideSelection(rect, xy)) {
+                return object;
+            }
+        }
+
+        return null;
+    }, [hitmapRef]);
+
+    const onPointerLeave = useCallback(() => {
+        window.document.body.style.cursor = 'auto';
+    }, []);
+
+    const onPointerDown = useCallback((e: PointerEvent<HTMLDivElement>) => {
+        const {
+            current: {
+                selection,
+                cellLayout: {columnToPixel, rowToPixel, pixelToCell, getIndentX, getIndentY},
+                visibleCells: {columns, rows},
+                knobPosition,
+            },
+        } = ref;
+
+        if (e.button !== 0) return;
+
+        (e.target as Element)?.setPointerCapture?.(e.pointerId);
+
+        const xy = getMousePosition(e);
+        if (!xy) return;
+
+        const [x, y] = xy;
+        const hitTarget = getMouseHit(xy);
+        if (hitTarget) {
+            setHitTarget(hitTarget);
+            return;
+        }
+
+        const [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
+
+        const selectedColumns = [];
+        const selectedRows = [];
+        for (let i = minX; i <= maxX; i++) selectedColumns.push(i);
+        for (let i = minY; i <= maxY; i++) selectedRows.push(i);
+
+        // Column header
+        if (!hideColumnHeaders && y < getIndentY()) {
+            // Grab selected columns in column selection
+            if (onColumnOrderChange) {
+                // Trim off start/end so resize works there
+                const start = columnToPixel(minX) + SIZES.resizeZone;
+                const end = columnToPixel(maxX, 1) - SIZES.resizeZone;
+                if (isInRange(x, start, end)) {
+
+                    for (const index of columns) {
+                        const start = columnToPixel(index, 0);
+                        const end = columnToPixel(index, 1);
+
+                        if (isColumnSelection(selection) && isInRange(x, start, end) && isInRange(index, minX, maxX)) {
+                            window.document.body.style.cursor = 'grabbing';
+
+                            const indices = selectedColumns;
+                            const size = columnToPixel(maxX, 1) - columnToPixel(minX);
+                            const [scroll] = getScrollPosition(e);
+
+                            setColumnDrag({
+                                anchor: x,
+                                scroll,
+                                size,
+                                indices,
+                            });
+                            onDragOffsetChange?.([0, 0]);
+                            return;
+                        }
+                    }
+                }
+            }
+
+            // Resize columns
+            if (onCellWidthChange) {
+                for (const index of columns) {
+                    const edge = columnToPixel(index, 1);
+
+                    if (Math.abs(edge - x) < SIZES.resizeZone) {
+                        window.document.body.style.cursor = 'col-resize';
+
+                        const asGroup = isColumnSelection(selection) && maxX === index;
+                        const indices = asGroup
+                            ? selectedColumns
+                            : [index];
+
+                        const size = asGroup
+                            ? columnToPixel(maxX, 1) - columnToPixel(minX)
+                            : columnToPixel(index, 1) - columnToPixel(index);
+                        const [scroll] = getScrollPosition(e);
+
+                        setColumnResize({
+                            anchor: x,
+                            scroll,
+                            size,
+                            indices,
+                        });
+                        return;
+                    }
+                }
+            }
+        }
+
+        if (!hideRowHeaders && x < getIndentX()) {
+            // Grab selected rows in row selection
+            if (onRowOrderChange) {
+                // Trim off start/end so resize works there
+                const start = rowToPixel(minY) + SIZES.resizeZone;
+                const end = rowToPixel(maxY, 1) - SIZES.resizeZone;
+                if (isInRange(y, start, end)) {
+
+                    for (const index of rows) {
+                        const start = rowToPixel(index, 0);
+                        const end = rowToPixel(index, 1);
+
+                        if (isRowSelection(selection) && isInRange(y, start, end) && isInRange(index, minY, maxY)) {
+                            window.document.body.style.cursor = 'grabbing';
+
+                            const indices = selectedRows;
+                            const size = rowToPixel(maxY, 1) - rowToPixel(minY);
+                            const [, scroll] = getScrollPosition(e);
+
+                            setRowDrag({
+                                anchor: y,
+                                scroll,
+                                size,
+                                indices,
+                            });
+                            onDragOffsetChange?.([0, 0]);
+                            return;
+                        }
+                    }
+                }
+            }
+
+            // Resize rows
+            if (onCellHeightChange) {
+                for (const index of rows) {
+                    const edge = rowToPixel(index, 1);
+
+                    if (Math.abs(edge - y) < SIZES.resizeZone) {
+                        window.document.body.style.cursor = 'row-resize';
+
+                        const asGroup = isRowSelection(selection) && maxY === index;
+                        const indices = asGroup
+                            ? selectedRows
+                            : [index];
+
+                        const size = asGroup
+                            ? rowToPixel(maxY, 1) - rowToPixel(minY)
+                            : rowToPixel(index, 1) - rowToPixel(index);
+                        const [, scroll] = getScrollPosition(e);
+
+                        setRowResize({
+                            anchor: y,
+                            scroll,
+                            size,
+                            indices,
+                        });
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Knob drag mode
+        if (knobPosition) {
+            const [knobX, knobY] = knobPosition;
+            if (Math.abs(x - knobX) < SIZES.knobArea && Math.abs(y - knobY) < SIZES.knobArea) {
+                setDraggingKnob(true);
+                onKnobAreaChange?.(selection);
+                return;
+            }
+        }
+
+        // Normal cell click
+        const head = pixelToCell(xy);
+        const anchor: XY = e.shiftKey ? [...selection[0]] : head;
+
+        if (editMode) {
+            if (!dontCommitEditOnSelectionChange) {
+                onCommit?.();
+            }
+        }
+
+        let scrollToHead = true;
+
+        if (!hideRowHeaders && x < getIndentX()) {
+            scrollToHead = false;
+            setDraggingRowSelection(true);
+            anchor[0] = -1;
+            head[0] = -1;
+        }
+
+        if (!hideColumnHeaders && y < getIndentY()) {
+            scrollToHead = false;
+            setDraggingColumnSelection(true);
+            anchor[1] = -1;
+            head[1] = -1;
+        }
+
+        setDraggingSelection(true);
+        onSelectionChange?.([anchor, head], scrollToHead);
+    }, [
+        getMousePosition,
+        getScrollPosition,
+        getMouseHit,
+        onColumnOrderChange,
+        onRowOrderChange,
+        onCellWidthChange,
+        onCellHeightChange,
+        onKnobAreaChange,
+        onSelectionChange,
+        onCommit,
+    ]);
+
+    const onPointerUp = useCallback((e: PointerEvent<HTMLDivElement>) => {
+        const {
+            current: {
+                knobArea,
+                selection,
+                sourceData,
+                editData,
+
+                columnDrag,
+                rowDrag,
+
+                draggingKnob,
+
+                cellLayout: {pixelToColumn, pixelToRow, getIndentX, getIndentY},
+            },
+        } = ref;
+
+        if (knobArea && draggingKnob) {
+            const changes = parseKnobOperation(knobArea, selection, sourceData, editData);
+
+            onChange?.(changes);
+            onSelectionChange?.(knobArea);
+            onKnobAreaChange?.(null);
+        }
+
+        const xy = getMousePosition(e);
+        if (xy && (columnDrag || rowDrag)) {
+            window.document.body.style.cursor = 'auto';
+            onDragOffsetChange?.(null);
+            onDropTargetChange?.(null);
+
+            const [x, y] = xy;
+            const [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
+
+            const cellX = pixelToColumn(Math.max(x, getIndentX()), 0.5);
+            const cellY = pixelToRow(Math.max(y, getIndentY()), 0.5);
+
+            if (columnDrag) {
+                const {indices} = columnDrag;
+
+                const insideSelection = cellX >= minX && cellX <= maxX + 1;
+                if (!insideSelection) {
+                    const order = cellX > minX ? cellX - indices.length : cellX;
+                    onSelectionChange?.([[order, minY], [order + maxX - minX, maxY]]);
+                    onColumnOrderChange?.(indices, order);
+                    onInvalidateColumn?.(Math.min(minX, order));
+                }
+            }
+            if (rowDrag) {
+                const {indices} = rowDrag;
+
+                const insideSelection = cellY >= minY && cellY <= maxY + 1;
+                if (!insideSelection) {
+                    const order = cellY > minY ? cellY - indices.length : cellY;
+                    onSelectionChange?.([[minX, order], [maxX, order + maxY - minY]]);
+                    onRowOrderChange?.(indices, order);
+                    onInvalidateRow?.(Math.min(minY, order));
+                }
+            }
+        }
+
+        setDraggingSelection(false);
+        setDraggingRowSelection(false);
+        setDraggingColumnSelection(false);
+        setDraggingKnob(false);
+        setColumnResize(null);
+        setColumnDrag(null);
+        setRowResize(null);
+        setRowDrag(null);
+
+        if (!xy || !hitTarget) return;
+        setHitTarget(null);
+
+        if (hitTarget === getMouseHit(xy)) {
+            const {obj} = hitTarget;
+            obj.onClick?.(e);
+        }
+
+    }, [
+        getMousePosition,
+        getMouseHit,
+        onChange,
+        onSelectionChange,
+        onKnobAreaChange,
+        onDropTargetChange,
+        onColumnOrderChange,
+        onRowOrderChange,
+    ]);
+
+    const onPointerMove = useCallback((e: PointerEvent<HTMLDivElement>) => {
+        const {
+            current: {
+                selection,
+                visibleCells,
+
+                knobPosition,
+                columnResize,
+                columnDrag,
+                rowResize,
+                rowDrag,
+
+                draggingKnob,
+                draggingSelection,
+                draggingColumnSelection,
+                draggingRowSelection,
+
+                cellLayout: {columnToPixel, rowToPixel, pixelToCell, pixelToColumn, pixelToRow, getIndentX, getIndentY},
+            },
+        } = ref;
+
+        const xy = getMousePosition(e);
+        if (!xy) return;
+
+        window.document.body.style.cursor = 'auto';
+
+        const hitTarget = getMouseHit(xy);
+        if (hitTarget) {
+            window.document.body.style.cursor = 'pointer';
+        }
+        else if (columnDrag || rowDrag) {
+            window.document.body.style.cursor = 'grabbing';
+        }
+        else if (columnResize) {
+            window.document.body.style.cursor = 'col-resize';
+            e.preventDefault();
+        }
+        else if (rowResize) {
+            window.document.body.style.cursor = 'row-resize';
+            e.preventDefault();
+        }
+        else if (draggingRowSelection || draggingColumnSelection) {
+            e.preventDefault();
+        }
+
+        const {columns, rows} = visibleCells;
+        const [x, y] = xy;
+        const [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
+
+        const isDragging = columnResize || columnDrag || rowResize || rowDrag || draggingRowSelection || draggingColumnSelection;
+
+        if (!isDragging) {
+            if (!hideColumnHeaders && y < getIndentY()) {
+                if (onColumnOrderChange) {
+                    // Trim off start/end so resize works there
+                    const start = columnToPixel(minX) + SIZES.resizeZone;
+                    const end = columnToPixel(maxX, 1) - SIZES.resizeZone;
+                    if (isInRange(x, start, end)) {
+
+                        for (const index of columns) {
+                            const start = columnToPixel(index);
+                            const end = columnToPixel(index, 1);
+
+                            if (
+                                !draggingColumnSelection &&
+                                isColumnSelection(selection) &&
+                                isInRange(x, start, end) &&
+                                isInRange(index, minX, maxX)
+                            ) {
+                                window.document.body.style.cursor = 'grab';
+                                return;
+                            }
+                        }
+                    }
+                }
+                if (onCellWidthChange) {
+                    for (const index of columns) {
+                        const edge = columnToPixel(index, 1);
+                        if (Math.abs(edge - x) < SIZES.resizeZone) {
+                            window.document.body.style.cursor = 'col-resize';
+                            return;
+                        }
+                    }
+                }
+            }
+
+            if (!hideRowHeaders && x < getIndentX()) {
+                if (onRowOrderChange) {
+                    // Trim off start/end so resize works there
+                    const start = rowToPixel(minY) + SIZES.resizeZone;
+                    const end = rowToPixel(maxY, 1) - SIZES.resizeZone;
+                    if (isInRange(y, start, end)) {
+
+                        for (const index of rows) {
+                            const start = rowToPixel(index);
+                            const end = rowToPixel(index, 1);
+
+                            if (
+                                !draggingRowSelection &&
+                                isRowSelection(selection) &&
+                                isInRange(y, start, end) &&
+                                isInRange(index, minY, maxY)
+                            ) {
+                                window.document.body.style.cursor = 'grab';
+                                return;
+                            }
+                        }
+                    }
+                }
+                if (onCellHeightChange) {
+                    for (const index of rows) {
+                        const edge = rowToPixel(index, 1);
+                        if (Math.abs(edge - y) < SIZES.resizeZone) {
+                            window.document.body.style.cursor = 'row-resize';
+                            return;
+                        }
+                    }
+                }
+            }
+
+            if (knobPosition) {
+                const [knobX, knobY] = knobPosition;
+                if (Math.abs(x - knobX) < SIZES.knobArea && Math.abs(y - knobY) < SIZES.knobArea) {
+                    window.document.body.style.cursor = 'crosshair';
+                    return;
+                }
+            }
+        }
+
+        if (columnResize) {
+            if (onCellWidthChange) {
+                const {size, anchor, scroll, indices} = columnResize;
+                const [currentScroll] = getScrollPosition(e);
+                const newWidth = Math.max(size + x - anchor + scroll - currentScroll, SIZES.minimumWidth * indices.length);
+                onInvalidateColumn?.(indices[0] - 1);
+                onCellWidthChange(indices, newWidth / indices.length);
+            }
+            return;
+        }
+
+        if (rowResize) {
+            if (onCellHeightChange) {
+                const {size, anchor, scroll, indices} = rowResize;
+                const [, currentScroll] = getScrollPosition(e);
+                const newHeight = Math.max(size + y - anchor + scroll - currentScroll, SIZES.minimumHeight * indices.length);
+                onInvalidateRow?.(indices[0] - 1);
+                onCellHeightChange(indices, newHeight / indices.length);
+            }
+            return;
+        }
+
+        if (draggingSelection) {
+            const [anchor] = selection;
+            const head = pixelToCell(xy);
+
+            const [anchorX, anchorY] = anchor;
+            const [headX, headY] = head;
+
+            if (draggingRowSelection) {
+                onSelectionChange?.([[-1, anchorY], [-1, Math.max(0, headY)]], false);
+            } else if (draggingColumnSelection) {
+                onSelectionChange?.([[anchorX, -1], [Math.max(0, headX), -1]], false);
+            } else {
+                onSelectionChange?.([
+                    maxXY(anchor, ORIGIN),
+                    maxXY(head, ORIGIN),
+                ], false);
+            }
+        }
+
+        if (draggingKnob) {
+            window.document.body.style.cursor = 'crosshair';
+
+            const [cellX, cellY] = pixelToCell(xy);
+            let [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
+
+            // check if vertical or horizontal
+            let xCellDiff = Math.min(cellX - minX, maxX - cellX, 0); // zero or less
+            let yCellDiff = Math.min(cellY - minY, maxY - cellY, 0); // zero or less
+
+            if (isMaybeRowSelection(selection) || xCellDiff > yCellDiff) {
+                if (cellY < minY) {
+                    minY = cellY;
+                } else if (cellY > maxY) {
+                    maxY = cellY;
+                }
+            } else {
+                if (cellX < minX) {
+                    minX = cellX;
+                } else if (cellX > maxX) {
+                    maxX = cellX;
+                }
+            }
+
+            onKnobAreaChange?.([[minX, minY], [maxX, maxY]]);
+        }
+
+        if (columnDrag || rowDrag) {
+            const [x, y] = xy;
+            if (columnDrag) {
+                const cellX = pixelToColumn(Math.max(x, getIndentX()), 0.5);
+                const insideSelection = cellX >= minX && cellX <= maxX + 1;
+
+                const {anchor, scroll} = columnDrag;
+                const shift = x - anchor;
+                const [currentScroll] = getScrollPosition(e);
+
+                onDragOffsetChange?.([shift + currentScroll - scroll, 0]);
+                onDropTargetChange?.(insideSelection ? null : [[cellX, -1], [cellX, -1]]);
+            }
+            if (rowDrag) {
+                const cellY = pixelToRow(Math.max(y, getIndentY()), 0.5);
+                const insideSelection = cellY >= minY && cellY <= maxY + 1;
+
+                const {anchor, scroll} = rowDrag;
+                const shift = y - anchor;
+                const [, currentScroll] = getScrollPosition(e);
+
+                onDragOffsetChange?.([0, shift + currentScroll - scroll]);
+                onDropTargetChange?.(insideSelection ? null : [[-1, cellY], [-1, cellY]]);
+            }
+        }
+    }, [
+        getMousePosition,
+        getScrollPosition,
+        getMouseHit,
+        onCellWidthChange,
+        onCellHeightChange,
+    ]);
+
+    const onDoubleClick = useCallback((e: MouseEvent) => {
+        const {
+            current: {
+                cellLayout: {pixelToCell},
+            },
+        } = ref;
+
+        e.preventDefault();
+        if (e.shiftKey) return;
+
+        const xy = getMousePosition(e);
+        if (!xy) return;
+
+        const hitTarget = getMouseHit(xy);
+        if (hitTarget) {
+            window.document.body.style.cursor = 'pointer';
+            return;
+        }
+
+        const editCell = pixelToCell(xy);
+        if (editMode) onCommit?.();
+        onEdit?.(editCell);
+    }, [getMousePosition, getMouseHit, onCommit, onEdit]);
+
+    const onContextMenu = useCallback((e: MouseEvent) => {
+        const {
+            current: {
+                cellLayout: {pixelToCell, getIndentX, getIndentY},
+            },
+        } = ref;
+
+        const xy = getMousePosition(e);
+        if (!xy) return;
+
+        const [x, y] = xy;
+        if (x <= getIndentX() || y <= getIndentY()) {
+            return;
+        }
+
+        // If click is not inside of selection, select the right clicked cell
+        const cell = pixelToCell(xy);
+        if (!isPointInsideSelection(selection, cell)) {
+            onSelectionChange?.([cell, cell]);
+        }
+
+        onPointerMove(e as any);
+
+        const [cellX, cellY] = cell;
+        const event: SheetMouseEvent = {
+            ...e,
+            cellX,
+            cellY,
+        };
+        onRightClick?.(event);
+    }, [getMousePosition, onSelectionChange, onPointerMove, onRightClick]);
+
+    const mouseHandlers = {
+        onPointerLeave,
+        onPointerDown,
+        onPointerMove,
+        onPointerUp,
+        onDoubleClick,
+        onContextMenu,
+    };
+
+    return {knobPosition, mouseHandlers};
+};
+
+const parseKnobOperation = (
+    knobArea: Rectangle,
+    selection: Rectangle,
+    sourceData: CellPropertyFunction<string | number | null>,
+    editData: CellPropertyFunction<string>,
+): Change[] => {
+    const [[kx1, ky1], [kx2, ky2]] = normalizeSelection(knobArea);
+    const [[sx1, sy1], [sx2, sy2]] = normalizeSelection(selection);
+
+    let fx1 = kx1;
+    let fy1 = ky1;
+    let fx2 = kx2;
+    let fy2 = ky2;
+
+    const changes: Change[] = [];
+
+    // TODO: this should be made less cryptic, using logical selection ops/fns
+
+    if (fx2 - fx1 === sx2 - sx1) {
+        // vertical
+        if (fy1 === sy1) {
+            fy1 = sy2 + 1;
+        } else {
+            fy2 = sy1 - 1;
+        }
+        if (fx1 === -1 && fx2 === -1) {
+            const [maxX] = findApproxMaxEditDataIndex(editData);
+            fx1 = 0;
+            fx2 = maxX;
+        }
+        let srcY = sy1;
+        for (let y = fy1; y <= fy2; y++) {
+            for (let x = fx1; x <= fx2; x++) {
+                const value = sourceData(x, srcY);
+                changes.push({ x: x, y: y, value: value, source: { x: x, y: srcY } });
+            }
+            srcY = srcY + 1;
+            if (srcY > sy2) {
+                srcY = sy1;
+            }
+        }
+    } else {
+        // horizontal
+        if (fx1 === sx1) {
+            fx1 = sx2 + 1;
+        } else {
+            fx2 = sx1 - 1;
+        }
+        if (fy1 === -1 && fy2 === -1) {
+            const [, maxY] = findApproxMaxEditDataIndex(editData);
+            fy1 = 0;
+            fy2 = maxY;
+        }
+        let srcX = sx1;
+        for (let x = fx1; x <= fx2; x++) {
+            for (let y = fy1; y <= fy2; y++) {
+                const value = sourceData(srcX, y);
+                changes.push({ x: x, y: y, value: value, source: { x: srcX, y: y } });
+            }
+            srcX = srcX + 1;
+            if (srcX > sx2) {
+                srcX = sx1;
+            }
+        }
+    }
+
+    return changes;
+}

--- a/src/props.ts
+++ b/src/props.ts
@@ -1,0 +1,138 @@
+import { Direction, XY, CellContentType, CellProperty, CellPropertyFunction, PropTypes, RowOrColumnProperty, RowOrColumnPropertyFunction } from './types';
+import { MAX_SEARCHABLE_INDEX, MAX_XY, ORIGIN } from './constants';
+import { clampXY, addXY, subXY, maxXY, getDirectionStep } from './coordinate';
+
+// Inject row/column props from an array, function, constant or default value
+export const createRowOrColumnProp = <T extends PropTypes>(
+    rowColProp: RowOrColumnProperty<T> | undefined,
+    defaultValue: T
+): RowOrColumnPropertyFunction<T> => {
+    if (Array.isArray(rowColProp)) {
+        return (rowOrColIndex: number) => {
+            if (rowOrColIndex >= 0 && rowOrColIndex < rowColProp.length) {
+                return rowColProp[rowOrColIndex];
+            } else {
+                return defaultValue;
+            }
+        };
+    } else if (typeof rowColProp === 'function') {
+        return rowColProp;
+    } else if (rowColProp !== null && rowColProp !== undefined) {
+        return () => rowColProp;
+    } else {
+        return () => defaultValue;
+    }
+}
+
+// Inject cell props from a nested array, function, constant or default value
+export const createCellProp = <T extends PropTypes>(
+    cellProp: CellProperty<T> | undefined,
+    defaultValue: T
+): CellPropertyFunction<T> => {
+    if (Array.isArray(cellProp)) {
+        return (x: number, y: number) => {
+            if (y >= 0 && y < cellProp.length) {
+                if (x >= 0 && x < cellProp[y].length) {
+                    return cellProp[y][x];
+                } else {
+                    return defaultValue;
+                }
+            } else {
+                return defaultValue;
+            }
+        };
+    } else if (typeof cellProp === 'function') {
+        return cellProp;
+    } else if (cellProp !== null && cellProp !== undefined) {
+        return () => cellProp;
+    } else {
+        return () => defaultValue;
+    }
+}
+
+export const findApproxMaxEditDataIndex = (editData: CellPropertyFunction<string>): XY => {
+    let x = 0;
+    let y = 0;
+    let howManyEmpty = 0;
+    let growthIncrement = 10;
+    let growthIncrementFactor = 1.5;
+
+    // x
+    while (howManyEmpty < 4) {
+        let allEmpty = true;
+        for (let yy = 0; yy < 10; yy++) {
+            const data = editData(x, yy);
+            if (data !== null && data !== undefined && data !== '') {
+                allEmpty = false;
+                break;
+            }
+        }
+        if (allEmpty) {
+            howManyEmpty += 1;
+        }
+        x += growthIncrement;
+        if (x > MAX_SEARCHABLE_INDEX) {
+            break;
+        }
+        growthIncrement = Math.floor(growthIncrement * growthIncrementFactor);
+    }
+
+    howManyEmpty = 0;
+    growthIncrement = 10;
+    growthIncrementFactor = 1.5;
+
+    // y
+    while (howManyEmpty < 4) {
+        let allEmpty = true;
+        for (let xx = 0; xx < 10; xx++) {
+            const data = editData(xx, y);
+            if (data !== null && data !== undefined && data !== '') {
+                allEmpty = false;
+                break;
+            }
+        }
+        if (allEmpty) {
+            howManyEmpty += 1;
+        }
+        y += growthIncrement;
+        if (y > MAX_SEARCHABLE_INDEX) {
+            break;
+        }
+        growthIncrement = Math.floor(growthIncrement * growthIncrementFactor);
+    }
+    return [x, y];
+}
+
+export const findInDisplayData = (
+    displayData: CellPropertyFunction<CellContentType>,
+    start: XY,
+    direction: Direction,
+): XY => {
+    const step = getDirectionStep(direction);
+
+    let cell = clampXY(start, ORIGIN, MAX_XY);
+    const first = displayData(...addXY(cell, step));
+    const firstFilled = first !== '' && first !== null && first !== undefined;
+
+    if (!firstFilled) {
+        cell = addXY(cell, step);
+    }
+
+    let [cellX, cellY] = cell;
+    while (cellX <= MAX_SEARCHABLE_INDEX && cellY <= MAX_SEARCHABLE_INDEX && cellX >= 0 && cellY >= 0) {
+        const data = displayData(cellX, cellY);
+
+        // if first cell is filled, find the last filled cell, so first look for first unfilled
+        if (firstFilled && (data === '' || data === null || data === undefined)) {
+            return subXY(cell, step);
+        }
+        // if first cell is not filled, just find the first filled
+        if (!firstFilled && data !== '' && data !== null && data !== undefined) {
+            return cell;
+        }
+
+        [cellX, cellY] = cell = addXY(cell, step);
+    }
+
+    return maxXY(cell, [0, 0]);
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,544 @@
+import { CellLayout, CellPropertyFunction, RowOrColumnPropertyFunction, InternalSheetStyle, Rectangle, Selection, Clickable, Style, CellContentType, VisibleLayout, XY } from './types';
+import { applyAlignment, resolveCellStyle } from './style';
+import { normalizeSelection, isEmptySelection, isRowSelection, isColumnSelection } from './coordinate';
+import { isInRange, isInRangeLeft, isInRangeRight, isInRangeCenter } from './util';
+import { COLORS, SIZES, DEFAULT_CELL_STYLE, DEFAULT_COLUMN_HEADER_STYLE, HEADER_SELECTED_STYLE, NO_STYLE, ONE_ONE } from './constants';
+
+export const renderSheet = (
+    context: CanvasRenderingContext2D,
+    cellLayout: CellLayout,
+    visibleCells: VisibleLayout,
+
+    sheetStyle: InternalSheetStyle,
+    cellStyle: CellPropertyFunction<Style>,
+
+    selection: Rectangle,
+    secondarySelections: Selection[],
+
+    knobPosition: XY | null,
+    knobArea: Rectangle | null,
+    dragOffset: XY | null,
+    dropTarget: Rectangle | null,
+
+    columnHeaders: RowOrColumnPropertyFunction<CellContentType>,
+    columnHeaderStyle: RowOrColumnPropertyFunction<Style>,
+    displayData: CellPropertyFunction<CellContentType>,
+
+    dataOffset: XY,
+): Clickable[] => {
+    const {canvas} = context;
+    const {width, height} = canvas;
+    const {
+        hideGridlines,
+        hideRowHeaders,
+        hideColumnHeaders,
+        rowHeaderWidth,
+        columnHeaderHeight,
+        freezeColumns,
+        freezeRows,
+    } = sheetStyle;
+    const {columns, rows} = visibleCells;
+    const {
+        columnToPixel,
+        rowToPixel,
+    } = cellLayout;
+
+    const clickables: Clickable[] = [];
+
+    const freeze: XY = [freezeColumns, freezeRows];
+    const indent: XY = [rowHeaderWidth, columnHeaderHeight];
+
+    resizeCanvas(canvas);
+    context.clearRect(0, 0, width, height);
+    context.fillStyle = 'white';
+    context.fillRect(0, 0, width, height);
+
+    // Cell fill
+    for (const y of rows) {
+        for (const x of columns) {
+            const left = columnToPixel(x);
+            const right = columnToPixel(x, 1);
+            const top = rowToPixel(y);
+            const bottom = rowToPixel(y, 1);
+
+            const {fillColor} = cellStyle(x, y);
+            if (fillColor) {
+                context.fillStyle = fillColor;
+                context.fillRect(left, top, right - left, bottom - top);
+            }
+        }
+    }
+
+    const selectionActive = !isEmptySelection(selection);
+    const rowSelectionActive = isRowSelection(selection);
+    const columnSelectionActive = isColumnSelection(selection);
+
+    // Get selection range
+    const [selected, hideKnob] = resolveFrozenSelection(
+        selection,
+        cellLayout,
+        freeze,
+        indent,
+        dataOffset,
+    );
+
+    // Selection fill
+    if (selectionActive) {
+        const [[left, top], [right, bottom]] = selected;
+        context.fillStyle = COLORS.selectionBackground;
+        context.fillRect(left, top, right - left, bottom - top);
+    }
+
+    if (!hideRowHeaders) {
+        // Row header background
+        context.fillStyle = COLORS.headerBackground;
+        context.fillRect(0, 0, rowHeaderWidth, context.canvas.height);
+
+        // Row header selection shadow
+        if (selectionActive && !columnSelectionActive) {
+            const [[, top], [, bottom]] = selected;
+            context.fillStyle = COLORS.headerActive;
+            context.fillRect(0, top, rowHeaderWidth, bottom - top);
+        }
+    }
+
+    if (!hideColumnHeaders) {
+        // Column header background
+        context.fillStyle = COLORS.headerBackground;
+        context.fillRect(0, 0, context.canvas.width, columnHeaderHeight);
+
+        // Column header selection shadow
+        if (selectionActive && !rowSelectionActive) {
+            const [[left], [right]] = selected;
+            context.fillStyle = COLORS.headerActive;
+            context.fillRect(left, 0, right - left, columnHeaderHeight);
+        }
+    }
+
+    // Grid
+    context.strokeStyle = COLORS.gridLine;
+    context.lineWidth = 1;
+
+    const gridRight = hideGridlines ? rowHeaderWidth : context.canvas.width;
+    const gridBottom = hideGridlines ? columnHeaderHeight : context.canvas.height;
+
+    const drawGridLineX = (x: number, height: number) => {
+        context.beginPath();
+        context.moveTo(x - .5, 0);
+        context.lineTo(x - .5, height);
+        context.stroke();
+    };
+
+    const drawGridLineY = (y: number, width: number) => {
+        context.beginPath();
+        context.moveTo(0, y - .5);
+        context.lineTo(width, y - .5);
+        context.stroke();
+    };
+
+    drawGridLineX(rowHeaderWidth, context.canvas.height);
+    drawGridLineY(columnHeaderHeight, context.canvas.width);
+
+    for (const column of columns) {
+        const right = columnToPixel(column, 1);
+        drawGridLineX(right, gridBottom);
+    }
+
+    for (const row of rows) {
+        const bottom = rowToPixel(row, 1);
+        drawGridLineY(bottom, gridRight);
+    }
+
+    const [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
+
+    // Row header text
+    if (!hideRowHeaders) {
+        context.textBaseline = 'middle';
+        context.textAlign = 'center';
+        context.font = DEFAULT_CELL_STYLE.fontSize + 'px ' + DEFAULT_CELL_STYLE.fontFamily;
+        context.fillStyle = COLORS.headerText;
+
+        for (const row of rows) {
+            const content = `${row + 1}`;
+
+            // Row selection mode
+            // (this is separate from the header selection shadow because we only want to highlight visible headers)
+            const style = (rowSelectionActive && !columnSelectionActive) && isInRange(row, minY, maxY)
+                ?  HEADER_SELECTED_STYLE : NO_STYLE;
+
+            const top = rowToPixel(row);
+            const bottom = rowToPixel(row, 1);
+
+            clickables.push(...renderCell(
+                context,
+                content,
+                style,
+                DEFAULT_COLUMN_HEADER_STYLE,
+                0,
+                top,
+                rowHeaderWidth,
+                bottom - top,
+            ));
+        }
+    }
+
+    // Column header text
+    if (!hideColumnHeaders) {
+        context.textBaseline = 'middle';
+        context.textAlign = 'center';
+
+        for (const column of columns) {
+            const content = columnHeaders(column) ?? excelHeaderString(column + 1);
+
+            // Column selection mode
+            // (this is separate from the header selection shadow because we only want to highlight visible headers)
+            const selectedStyle = (columnSelectionActive && !rowSelectionActive) && isInRange(column, minX, maxX)
+                ? HEADER_SELECTED_STYLE : NO_STYLE;
+            const style = {
+                ...columnHeaderStyle(column),
+                ...selectedStyle,
+            };
+
+            const left = columnToPixel(column);
+            const right = columnToPixel(column, 1);
+
+            clickables.push(...renderCell(
+                context,
+                content,
+                style,
+                DEFAULT_COLUMN_HEADER_STYLE,
+                left,
+                0,
+                right - left,
+                columnHeaderHeight
+            ));
+        }
+    }
+
+    // Selection outline
+    if (selectionActive) {
+        context.strokeStyle = COLORS.selectionBorder;
+        context.lineWidth = (rowSelectionActive || columnSelectionActive) ? 2 : 1;
+
+        const [[left, top], [right, bottom]] = selected;
+        context.strokeRect(left - 1, top - 1, right - left + 1, bottom - top + 1);
+    }
+
+    for (const secondarySelection of secondarySelections) {
+        const selection = secondarySelection.span;
+        if (isEmptySelection(selection)) continue;
+
+        const [selected] = resolveFrozenSelection(
+            selection,
+            cellLayout,
+            freeze,
+            indent,
+            dataOffset,
+        );
+        const [[left, top], [right, bottom]] = selected;
+
+        context.strokeStyle = secondarySelection.color;
+        context.lineWidth = 1;
+        context.beginPath();
+        context.strokeRect(left - 1, top - 1, right - left + 1, bottom - top + 1);
+    }
+
+    // Knob drag outline
+    if (knobArea) {
+        let [[minX, minY], [maxX, maxY]] = normalizeSelection(knobArea);
+        const left = columnToPixel(minX);
+        const top = rowToPixel(minY);
+        const right = columnToPixel(maxX, 1);
+        const bottom = rowToPixel(maxY, 1);
+
+        context.strokeStyle = COLORS.knobAreaBorder;
+        context.setLineDash([3, 3]);
+        context.lineWidth = 1;
+
+        context.strokeRect(left - 1, top - 1, right - left + 1, bottom - top + 1);
+        context.setLineDash([]);
+    }
+
+    // Selection knob
+    if (knobPosition && !hideKnob) {
+        const [knobX, knobY] = knobPosition;
+        context.fillStyle = COLORS.selectionBorder;
+        context.fillRect(knobX - SIZES.knobArea * 0.5, knobY - SIZES.knobArea * 0.5, SIZES.knobArea, SIZES.knobArea);
+    }
+
+    // Drag ghost (pixels)
+    if (dragOffset) {
+        const [shiftX, shiftY] = dragOffset;
+        const [[left, top], [right, bottom]] = resolveSelection(selection, cellLayout);
+
+        context.fillStyle = COLORS.dragGhost;
+        context.fillRect(left + shiftX, top + shiftY, right - left, bottom - top);
+    }
+
+    // Drop target
+    if (dropTarget) {
+        let [[left, top], [right, bottom]] = resolveSelection(dropTarget, cellLayout);
+
+        context.strokeStyle = COLORS.dropTarget;
+        context.lineWidth = 2;
+
+        if (isColumnSelection(dropTarget)) {
+            right = left;
+        }
+        if (isRowSelection(dropTarget)) {
+            bottom = top;
+        }
+        context.strokeRect(left - 1, top - 1, right - left + 1, bottom - top + 1);
+    }
+
+    // Cell contents
+    context.textBaseline = 'middle';
+
+    for (const y of rows) {
+        for (const x of columns) {
+            const left = columnToPixel(x);
+            const right = columnToPixel(x, 1);
+            const top = rowToPixel(y);
+            const bottom = rowToPixel(y, 1);
+
+            const cellContent = displayData(x, y);
+            if (cellContent !== null && cellContent !== undefined) {
+                const style = cellStyle(x, y);
+                clickables.push(...renderCell(context, cellContent, style, DEFAULT_CELL_STYLE, left, top, right - left, bottom - top));
+            }
+        }
+    }
+
+    return clickables;
+};
+
+export const renderCell = (
+    context: CanvasRenderingContext2D,
+    cellContent: CellContentType,
+    style: Style,
+    defaultCellStyle: Required<Style>,
+    xCoord: number,
+    yCoord: number,
+    cellWidth: number,
+    cellHeight: number
+): Clickable[] => {
+    const clickables: Clickable[] = [];
+
+    if (cellContent === null) {
+        return clickables;
+    }
+
+    const finalStyle = resolveCellStyle(style, defaultCellStyle);
+    context.fillStyle = finalStyle.color;
+    context.font = finalStyle.weight + ' ' + finalStyle.fontSize + 'px ' + finalStyle.fontFamily;
+    context.textAlign = finalStyle.textAlign;
+
+    const yy = Math.floor(yCoord + cellHeight * 0.5);
+
+    context.save();
+    context.beginPath();
+    context.rect(xCoord, yCoord, cellWidth, cellHeight);
+    context.clip();
+
+    if (finalStyle.backgroundColor !== '') {
+        context.fillStyle = finalStyle.backgroundColor;
+        context.fillRect(xCoord, yCoord, cellWidth, cellHeight);
+        context.fillStyle = finalStyle.color;
+    }
+
+    if (typeof cellContent === 'string' || typeof cellContent === 'number') {
+        const xx = applyAlignment(xCoord, cellWidth, finalStyle, 0);
+        const text = '' + cellContent;
+        context.fillText(text, xx, yy);
+    } else if (typeof cellContent === 'object') {
+        for (const obj of cellContent.items) {
+            let x = 0;
+            let y = 0;
+            let w = 0;
+            let h = 0;
+
+            if (obj.content instanceof HTMLImageElement) {
+                w = obj.width || cellWidth;
+                h = obj.height || cellHeight;
+
+                const finalX = applyAlignment(xCoord, cellWidth, finalStyle, w, obj.horizontalAlign);
+                x = finalX + obj.x;
+                y = yy + obj.y;
+
+                context.drawImage(obj.content, x, y, w, h);
+            } else if (typeof obj.content === 'string' || typeof obj.content === 'number') {
+                if (obj.horizontalAlign) {
+                    context.textAlign = obj.horizontalAlign;
+                }
+                const finalX = applyAlignment(xCoord, cellWidth, finalStyle, 0, obj.horizontalAlign);
+                const text = '' + obj.content;
+
+                const left = finalX + obj.x;
+                const top = yy + obj.y;
+                context.fillText(text, left, top);
+
+                const measure = context.measureText(text);
+                x = left - measure.actualBoundingBoxLeft;
+                y = top - measure.actualBoundingBoxAscent;
+                w = left + measure.actualBoundingBoxRight - x;
+                h = top + measure.actualBoundingBoxDescent - y;
+            }
+            if (obj.onClick) {
+                clickables.push({
+                    rect: [[x, y], [x + w, y + h]],
+                    obj,
+                });
+            }
+        }
+    }
+    context.restore();
+
+    return clickables;
+};
+
+// Resolve selection into a consistent rectangle, without dealing with frozen rows/columns
+const resolveSelection = (
+    selection: Rectangle,
+    cellLayout: CellLayout,
+) => {
+    const {cellToPixel} = cellLayout;
+
+    const rowSelectionActive = isRowSelection(selection);
+    const columnSelectionActive = isColumnSelection(selection);
+
+    // Get selection range
+    const [min, max] = normalizeSelection(selection);
+
+    // Direct projection to visible grid
+    let [left, top] = cellToPixel(min);
+    let [right, bottom] = cellToPixel(max, ONE_ONE);
+
+    // Extend full row/column selection infinitely right/down
+    if (rowSelectionActive) {
+        right = 1e5;
+    }
+    if (columnSelectionActive) {
+        bottom = 1e5;
+    }
+
+    return [[left, top], [right, bottom]];
+};
+
+// Resolve selection into a consistent rectangle, handling edge cases around frozen rows/columns.
+const resolveFrozenSelection = (
+    selection: Rectangle,
+    cellLayout: CellLayout,
+
+    freeze: XY,
+    indent: XY,
+    offset: XY,
+) => {
+    const {cellToPixel, columnToAbsolute, rowToAbsolute} = cellLayout;
+
+    const rowSelectionActive = isRowSelection(selection);
+    const columnSelectionActive = isColumnSelection(selection);
+
+    const [freezeX, freezeY] = freeze;
+    const [indentX, indentY] = indent;
+    const [offsetX, offsetY] = offset;
+
+    // Get selection range
+    const [min, max] = normalizeSelection(selection);
+    const [minX, minY] = min;
+    const [maxX, maxY] = max;
+
+    // Direct projection to visible grid
+    let [left, top] = cellToPixel(min);
+    let [right, bottom] = cellToPixel(max, ONE_ONE);
+
+    // Get frozen edge
+    const frozenX = columnToAbsolute(freezeX);
+    const frozenY = rowToAbsolute(freezeY);
+
+    let hideKnob = false;
+
+    // If the selection crosses the frozen edge, it needs to always cover the entire frozen area.
+    if (isInRangeCenter(freezeX, minX, maxX + 1)) {
+        const edge = indentX + frozenX;
+        if (right <= edge) {
+            right = edge;
+            hideKnob = true;
+        }
+    }
+    if (isInRangeCenter(freezeY, minY, maxY + 1)) {
+        const edge = indentY + frozenY;
+        if (bottom <= edge) {
+            bottom = edge;
+            hideKnob = true;
+        }
+    }
+
+    // If the selection starts/ends under the frozen area, treat as off-screen
+    if (isInRangeLeft(minX, freezeX, offsetX + freezeX)) {
+        left = -1e5;
+        if (isInRangeRight(maxX + 1, freezeX, offsetX + freezeX)) {
+            right = indentX;
+            hideKnob = true;
+        }
+    }
+    if (isInRangeLeft(minY, freezeY, offsetY + freezeY)) {
+        top = -1e5;
+        if (isInRangeRight(maxY + 1, freezeY, offsetY + freezeY)) {
+            bottom = indentY;
+            hideKnob = true;
+        }
+    }
+
+    if (rowSelectionActive && offsetX > 0) {
+        hideKnob = true;
+    }
+    if (columnSelectionActive && offsetY > 0) {
+        hideKnob = true;
+    }
+
+    // Extend full row/column selection infinitely right/down
+    if (rowSelectionActive) {
+        right = 1e5;
+    }
+    if (columnSelectionActive) {
+        bottom = 1e5;
+    }
+
+    return [
+        [[left, top], [right, bottom]],
+        hideKnob,
+    ] as [Rectangle, boolean];
+};
+
+const resizeCanvas = (canvas: HTMLCanvasElement) => {
+    const { width, height } = canvas.getBoundingClientRect();
+    let { devicePixelRatio: ratio = 1 } = window;
+    if (ratio < 1) {
+        ratio = 1;
+    }
+    const newCanvasWidth = Math.round(width * ratio);
+    const newCanvasHeight = Math.round(height * ratio);
+
+    if (canvas.width !== newCanvasWidth || canvas.height !== newCanvasHeight) {
+        const context = canvas.getContext('2d');
+        if (context) {
+            canvas.width = newCanvasWidth;
+            canvas.height = newCanvasHeight;
+            context.scale(ratio, ratio);
+        }
+        return true;
+    }
+
+    return false;
+};
+
+const excelHeaderString = (num: number) => {
+    let s = '';
+    let t = 0;
+    while (num > 0) {
+        t = (num - 1) % 26;
+        s = String.fromCharCode(65 + t) + s;
+        num = ((num - t) / 26) | 0;
+    }
+    return s || '';
+};

--- a/src/scroll.ts
+++ b/src/scroll.ts
@@ -1,0 +1,100 @@
+import { UIEvent, useCallback } from 'react';
+import { XY, CellLayout } from './types';
+import { isSameXY, maxXY, mulXY } from './coordinate';
+import { ONE_ONE } from './constants';
+
+export const useScroll = (
+    offset: XY,
+    maxScroll: XY,
+    cellLayout: CellLayout,
+    onOffsetChange?: (offset: XY) => void,
+    onMaxScrollChange?: (maxScroll: XY) => void,
+) => {
+    return useCallback((e: UIEvent) => {
+        if (!e.target || !(e.target instanceof Element)) {
+            return;
+        }
+
+        const xy: XY = [
+            e.target.scrollLeft,
+            e.target.scrollTop,
+        ];
+
+        const {absoluteToCell} = cellLayout;
+        const cell = absoluteToCell(xy);
+        if (!isSameXY(cell, offset)) {
+            onOffsetChange?.(cell);
+        }
+
+        // TODO: smooth scrolling
+        // const pixel = subXY(cellToAbsolute(cell), xy);
+        //if (!isSameXY(pixel, pixelOffset)) {
+        //     setPixelOffset(pixel);
+        //}
+
+        const [x, y] = xy;
+        const [maxScrollX, maxScrollY] = maxScroll;
+        const growX = (maxScrollX < x + 1) ? 1.5 : 1;
+        const growY = (maxScrollY < y + 1) ? 1.5 : 1;
+        if (growX > 1 || growY > 1) {
+            onMaxScrollChange?.(mulXY(maxScroll, [growX, growY]));
+        }
+    }, [cellLayout, onOffsetChange, onMaxScrollChange]);
+};
+
+export const scrollToCell = (
+    element: HTMLDivElement,
+    cell: XY,
+    view: XY,
+    freeze: XY,
+    offset: XY,
+    maxScroll: XY,
+    cellLayout: CellLayout,
+    callback: (offset: XY, maxScroll: XY) => void,
+) => {
+    const [x, y] = cell;
+    const [w, h] = view;
+    const [offsetX, offsetY] = offset;
+
+    const {cellToAbsolute, cellToPixel, columnToPixel, rowToPixel} = cellLayout;
+    const [frozenX, frozenY] = cellToAbsolute(freeze);
+    const [left, top] = cellToPixel(cell);
+    const [right, bottom] = cellToPixel(cell, ONE_ONE);
+
+    let [newX, newY] = offset;
+
+    // If moving left/up, scroll to head
+    if (left <= frozenX) {
+        newX = x;
+    }
+    if (top <= frozenY) {
+        newY = y;
+    }
+
+    // If moving right/down, scroll cell by cell until right/bottom of cell is visible
+    if (right > w) {
+        let edge = right - w + columnToPixel(newX);
+        while (columnToPixel(++newX) < edge) {};
+    }
+    if (bottom > h) {
+        let edge = bottom - h + rowToPixel(newY);
+        while (rowToPixel(++newY) < edge) {};
+    }
+
+    // Don't scroll on infinite axis
+    const newOffset: XY = [
+        newX >= 0 ? newX : offsetX,
+        newY >= 0 ? newY : offsetY,
+    ];
+
+    if (!isSameXY(newOffset, offset)) {
+        const scroll = cellToAbsolute(newOffset);
+
+        callback(newOffset, maxXY(maxScroll, scroll));
+        setTimeout(() => {
+            const [scrollX, scrollY] = scroll;
+            element.scrollLeft = scrollX;
+            element.scrollTop = scrollY;
+        });
+    }
+};

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,0 +1,39 @@
+import { InternalSheetStyle, SheetStyle, Style } from './types';
+import { SIZES } from './constants';
+
+export const resolveSheetStyle = (sheetStyle?: SheetStyle): InternalSheetStyle => {
+    return {
+        freezeColumns: sheetStyle?.freezeColumns || 0,
+        freezeRows: sheetStyle?.freezeRows || 0,
+        hideColumnHeaders: sheetStyle?.hideColumnHeaders || false,
+        hideRowHeaders: sheetStyle?.hideRowHeaders || false,
+        hideGridlines: sheetStyle?.hideGridlines || false,
+        hideScrollBars: sheetStyle?.hideScrollBars || false,
+        columnHeaderHeight: sheetStyle?.hideColumnHeaders ? 1 : SIZES.headerHeight,
+        rowHeaderWidth: sheetStyle?.hideRowHeaders ? 1 : SIZES.headerWidth,
+    };
+};
+
+export const resolveCellStyle = (optionalStyle: Style, defaultStyle: Required<Style>): Required<Style> => {
+    return {
+        ...defaultStyle,
+        ...optionalStyle,
+    };
+};
+
+export const applyAlignment = (
+    start: number,
+    cellSize: number,
+    style: Required<Style>,
+    imageWidth: number,
+    alignment: 'left' | 'center' | 'right' = style.textAlign,
+): number => {
+    if (alignment === 'left') {
+        return start + style.marginLeft;
+    } else if (alignment === 'center') {
+        return start + cellSize * 0.5 - imageWidth / 2;
+    } else if (alignment === 'right') {
+        return start + (cellSize - style.marginRight - imageWidth);
+    }
+    return start;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,183 @@
+import {
+    MouseEvent,
+    PointerEvent,
+    CSSProperties,
+} from 'react';
+
+////////////////////////////////////////////////////////////////////////////////
+// Props
+////////////////////////////////////////////////////////////////////////////////
+
+export type PropTypes = string | number | boolean | Style | CellContentType;
+
+export type CellPropertyFunction<T extends PropTypes> = (x: number, y: number) => T;
+export type RowOrColumnPropertyFunction<T extends PropTypes> = (rowOrColIndex: number) => T;
+
+export type CellProperty<T extends PropTypes> = T | T[][] | CellPropertyFunction<T>;
+export type RowOrColumnProperty<T extends PropTypes> = T | T[] | RowOrColumnPropertyFunction<T>;
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Content
+////////////////////////////////////////////////////////////////////////////////
+
+export type CellContentType = null | number | string | CellContent;
+export type CellContent = {
+    items: CellContentItem[],
+};
+
+export type CellContentItem = {
+    content: HTMLImageElement | string | number,
+    x: number,
+    y: number,
+    width?: number,
+    height?: number,
+    horizontalAlign?: 'left' | 'right' | 'center',
+    onClick?: (e: MouseEvent) => void,
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Selections
+////////////////////////////////////////////////////////////////////////////////
+
+export type XY = [number, number];
+export type Rectangle = [XY, XY];
+
+export type Direction = 'up' | 'down' | 'left' | 'right';
+
+export type LayoutCache = {
+    getSize: (i: number) => number,
+    getStart: (i: number) => number,
+    getEnd: (i: number) => number,
+
+    lookupIndex: (i: number, anchor?: number) => number,
+
+    getVersion: () => number,
+    clearAfter: (i: number) => void,
+    setSizer: (s: (i: number) => number) => void,
+};
+
+export type CellLayout = {
+    cellToPixel: (cell: XY, anchor?: XY) => XY,
+    pixelToCell: (pixel: XY, anchor?: XY) => XY,
+
+    cellToAbsolute: (cell: XY, anchor?: XY) => XY,
+    absoluteToCell: (pixel: XY, anchor?: XY) => XY,
+
+    columnToPixel: (column: number, anchor?: number) => number,
+    rowToPixel: (column: number, anchor?: number) => number,
+    pixelToColumn: (pixel: number, anchor?: number) => number,
+    pixelToRow: (pixel: number, anchor?: number) => number,
+
+    columnToAbsolute: (column: number, anchor?: number) => number,
+    rowToAbsolute: (column: number, anchor?: number) => number,
+    absoluteToColumn: (pixel: number, anchor?: number) => number,
+    absoluteToRow: (pixel: number, anchor?: number) => number,
+
+    getVisibleCells: (view: XY) => VisibleLayout,
+    getIndentX: () => number,
+    getIndentY: () => number,
+
+    getVersion: () => number,
+};
+
+export type VisibleLayout = {
+    columns: number[],
+    rows: number[],
+};
+
+export type Selection = {
+    span: Rectangle,
+    color: string,
+};
+
+export type Clickable = {
+    rect: Rectangle,
+    obj: CellContentItem,
+};
+
+export type Resizable = {
+    rect: Rectangle,
+    anchor: number,
+    size: number,
+    indices: number[],
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Changes
+////////////////////////////////////////////////////////////////////////////////
+
+export type Change = {
+    x: number,
+    y: number,
+    value: string | number | null,
+    source?: { x: number; y: number },
+};
+
+export type ParsedChange = {
+    selection: Rectangle,
+    changes: Change[],
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Events
+////////////////////////////////////////////////////////////////////////////////
+
+export type SheetMouseEvent = MouseEvent & {
+    cellX: number;
+    cellY: number;
+};
+
+export type SheetPointerEvent = PointerEvent & {
+    cellX: number;
+    cellY: number;
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Styling
+////////////////////////////////////////////////////////////////////////////////
+
+export type InputStyle = Pick<
+    CSSProperties,
+    | 'position'
+    | 'top'
+    | 'left'
+    | 'width'
+    | 'height'
+    | 'outline'
+    | 'border'
+    | 'textAlign'
+    | 'color'
+    | 'fontSize'
+    | 'fontFamily'
+>;
+
+export type Style = {
+    color?: string,
+    fontSize?: number,
+    fontFamily?: string,
+    textAlign?: 'right' | 'left' | 'center',
+    marginRight?: number,
+    marginLeft?: number,
+    weight?: string,
+    fillColor?: string,
+    backgroundColor?: string,
+};
+
+export type SheetStyle = {
+    hideGridlines?: boolean;
+    hideColumnHeaders?: boolean;
+    hideRowHeaders?: boolean;
+    hideScrollBars?: boolean;
+    freezeColumns?: number;
+    freezeRows?: number;
+};
+
+export type InternalSheetStyle = Required<SheetStyle> & {
+    columnHeaderHeight: number;
+    rowHeaderWidth: number;
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,11 @@
+export const tail = <T,>(list: T[]): T => list[list.length - 1];
+
+export const clamp = (x: number, min: number, max: number) => Math.max(Math.min(max, x), min);
+
+export const seq = (n: number, s: number = 0, d: number = 1): number[] => Array.from({ length: n }).map((_, i: number) => s + d * i);
+
+export const isInRange = (x: number, min: number, max: number) => min <= x && x <= max;
+export const isInRangeLeft = (x: number, min: number, max: number) => min <= x && x < max;
+export const isInRangeRight = (x: number, min: number, max: number) => min < x && x <= max;
+export const isInRangeCenter = (x: number, min: number, max: number) => min < x && x < max;
+


### PR DESCRIPTION
Reorganization
- move types to `./types`
- move constants to `./constants`, group `COLORS` and `SIZES`
- move styling code to `./style`, clarify `createStyleObject` into `resolveSheetStyle` and `resolveCellStyle`
- move coordinate code to `./coordinate`
- move rendering code to `./render`
- move copy/paste code to `./clipboard`
- move scrolling code to `./scroll`
- move mouse code to `./mouse` and useCallback / useRef it

New features
- restyle column/row selection
- drag and drop column/row selection
- imperative handle ref with access to cell layout for external use
- optional `cacheLayout` mode that assumes only the sheet is changing the `cellWidth` / `cellHeight` for 1m+ rows

Refactoring
- calculate hitmap during rendering and pass back using a ref instead of doing layout twice
- add various selection utils to `./coordinate` and use everywhere (e.g. `isSameSelection`, `isRowSelection`, ...)
- centralize mouse testing code into `getMousePosition` and `getMouseHit`
- use inline `setState` for `editKeys` instead of `useEffect + setState`
- do exact hitmap test instead of x/y binning, plenty fast enough
- replace `calculateRowOrColumnSizes(...)` with a virtual layout that can access any cell in the sheet, simplify scrolling logic
- add `anchor` [0..1] to `cellToPixel(...)` style lookups to get position within cell
- align canvas line strokes to exact pixels
- use `event.shiftKey` instead of tracking `shiftKeyDown`

Code style
- prefer `minX` / `maxX` instead of `x1`/`x2` when guaranteed to be oriented
- use `left/top/right/bottom` in a layout context for insertion points/boxes, it is easy to read and CSS-like
- use `XY` and `Rectangle` type [number, number] and [XY, XY]
  => a selection is made out of two points, don't need to immediately unpack to `{x1, y1, x2, y2}`
  => this allows for easy renaming-while-unpacking, which happens a lot
  => it also avoids typing `{x: , y: }` a lot
  => this avoids mutating `.x` / `.y` directly, which can lead to mutability errors. points and rects should be immutable
  => encourages using `XY` as a datatype for args and structs instead of inlining `fooX` and `fooY`
