### PR TITLE
#18 / #19 / #20

### DIFF
--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -331,7 +331,7 @@ export const useMouse = (
             }
         }
 
-        let scrollToHead = true;
+        let scrollToHead = !e.shiftKey;
 
         if (!hideRowHeaders && x < getIndentX()) {
             scrollToHead = false;

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,7 +1,7 @@
 import { CellLayout, CellPropertyFunction, RowOrColumnPropertyFunction, InternalSheetStyle, Rectangle, Selection, Clickable, Style, CellContentType, VisibleLayout, XY } from './types';
 import { applyAlignment, resolveCellStyle } from './style';
 import { normalizeSelection, isEmptySelection, isRowSelection, isColumnSelection } from './coordinate';
-import { isInRange, isInRangeLeft, isInRangeRight, isInRangeCenter } from './util';
+import { isInRange, isInRangeLeft, isInRangeCenter } from './util';
 import { COLORS, SIZES, DEFAULT_CELL_STYLE, DEFAULT_COLUMN_HEADER_STYLE, HEADER_SELECTED_STYLE, HEADER_ACTIVE_STYLE, NO_STYLE, ONE_ONE } from './constants';
 
 export const renderSheet = (
@@ -485,15 +485,21 @@ const resolveFrozenSelection = (
     // If the selection starts/ends under the frozen area, treat as off-screen
     if (isInRangeLeft(minX, freezeX, offsetX + freezeX)) {
         left = -1e5;
-        if (isInRangeRight(maxX + 1, freezeX, offsetX + freezeX)) {
-            right = indentX;
+
+        const lastInvisibleX = offsetX + freezeX - 1;
+        if (maxX <= lastInvisibleX) {
+            if (maxX === lastInvisibleX) right = indentX;
+            else right = -1e5;
             hideKnob = true;
         }
     }
     if (isInRangeLeft(minY, freezeY, offsetY + freezeY)) {
         top = -1e5;
-        if (isInRangeRight(maxY + 1, freezeY, offsetY + freezeY)) {
-            bottom = indentY;
+
+        const lastInvisibleY = offsetY + freezeY - 1;
+        if (maxY <= lastInvisibleY) {
+            if (maxY === lastInvisibleY) bottom = indentY;
+            else bottom = -1e5;
             hideKnob = true;
         }
     }

--- a/src/scroll.ts
+++ b/src/scroll.ts
@@ -14,13 +14,16 @@ export const useScroll = (
         if (!e.target || !(e.target instanceof Element)) {
             return;
         }
+        const {absoluteToCell, cellToAbsolute} = cellLayout;
+
+        // Zero scroll position is considered in the center of the top/left cell
+        const [nudgeX, nudgeY] = cellToAbsolute([0, 0], [0.5, 0.5]);
 
         const xy: XY = [
-            e.target.scrollLeft,
-            e.target.scrollTop,
+            e.target.scrollLeft + nudgeX,
+            e.target.scrollTop + nudgeY,
         ];
 
-        const {absoluteToCell} = cellLayout;
         const cell = absoluteToCell(xy);
         if (!isSameXY(cell, offset)) {
             onOffsetChange?.(cell);
@@ -89,12 +92,13 @@ export const scrollToCell = (
 
     if (!isSameXY(newOffset, offset)) {
         const scroll = cellToAbsolute(newOffset);
+        const [nudgeX, nudgeY] = cellToAbsolute([0, 0], [0.5, 0.5]);
 
         callback(newOffset, maxXY(maxScroll, scroll));
         setTimeout(() => {
             const [scrollX, scrollY] = scroll;
-            element.scrollLeft = scrollX;
-            element.scrollTop = scrollY;
+            element.scrollLeft = scrollX - nudgeX;
+            element.scrollTop = scrollY - nudgeY;
         });
     }
 };


### PR DESCRIPTION
- Fix scroll when selecting while holding shift
- Only show off-screen selection hint if selection is in adjacent row/column
- Only need to scroll half the first row/cell to get to second row/column