### PR TITLE
Knob scroll fix, empty cell scroll workaround

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -16,7 +16,13 @@ export const useClipboardCopy = (
         if (editMode) return;
         if (isEmptySelection(selection)) return;
 
-        textArea.value = formatSelectionAsTSV(selection, editData);
+        let v = formatSelectionAsTSV(selection, editData);
+
+        // Bizarre: having only TAB/RETURN characters inside the textarea
+        // prevents native auto-scroll. Also bizarre: auto-scroll doesn't work
+        // if we don't focus the textarea at all.
+        if (v.match(/^[\t\n]*$/)) { v = ' ' + v; }
+        textArea.value = v;
     }, [selection, editMode, editData, textAreaRef]);
 
     useLayoutEffect(() => {

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -387,7 +387,7 @@ export const useMouse = (
             const changes = parseKnobOperation(knobArea, selection, sourceData, editData);
 
             onChange?.(changes);
-            onSelectionChange?.(knobArea);
+            onSelectionChange?.(knobArea, true, true);
             onKnobAreaChange?.(null);
         }
 


### PR DESCRIPTION
- Fixes knob drag scrolling to selection anchor instead of head
  https://github.com/farseerdev/sheet-happens/issues/23
- Adds workaround for empty cell selection scrolling
  https://github.com/farseerdev/sheet-happens/issues/24
 
Note: there is no actual auto-scroll behavior coded, it's just the browser doing it. And there is no `event.preventDefault()` being called in either case, with or without data in the cell. It is instead related to the clipboard feature.

**How it works**
- the sheet uses an invisible textarea to handle copying of cells
- this textarea is updated whenever the selection changes
- this textarea takes focus whenever you click the grid with `textArea.focus({ preventScroll: true })`

**The bug**
- if the selection only covers empty cells, the textarea only has `tab` and `enter` characters in it (TSV)
- when you click to start a new selection, the textarea loses focus
- the next render we will re-focus the textarea
- focusing the textarea will cause the browser's native auto-scrolling to kick in on the sheet overlay...
- but only if the textarea contains something other than `tab` and `enter`

If I comment out these two lines:
```
            textArea.focus({ preventScroll: true });
            textArea.select();
```

Then it never auto-scrolls.

As a workaround we can put a space on the clipboard if it's only whitespace:
```
        if (v.match(/^[\t\n]*$/)) { v = ' ' + v; }
```

My guess is that this is something inside the browser, where the native behavior for text selection is kicking in (with auto-scroll) because we are messing around with the textarea during a click. But it's not reliable.

Longer term it would be better to use the native clipboard API (which would also fix the performance issues with large selections) and just add our own auto-scroll.