### PR TITLE
render outside should size container and disable pointer events

### DIFF
--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -614,6 +614,9 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
                         position: 'absolute',
                         left: 0,
                         top: 0,
+                        width: '100%',
+                        height: '100%',
+                        pointerEvents: 'none',
                     }}
                 >
                     {renderedOutside}


### PR DESCRIPTION
otherwise we can't size the overlays exactly