### PR TITLE
fix custom element click not firing

### DIFF
--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -78,7 +78,7 @@ export const useMouse = (
         return null;
     }, [selection, cellToPixel, version]);
 
-    // Pass dragging state into handlers via ref so they don't need to rebind during resizes/drags
+    // Pass pointer/dragging state into handlers via ref so they don't need to rebind during resizes/drags
     const refState = {
         selection,
         knobArea,
@@ -87,6 +87,7 @@ export const useMouse = (
         sourceData,
         cellLayout,
         visibleCells,
+        hitTarget,
 
         knobPosition,
         columnResize,
@@ -166,6 +167,8 @@ export const useMouse = (
         const hitTarget = getMouseHit(xy);
         if (hitTarget) {
             setHitTarget(hitTarget);
+            // Update hitTarget in ref in case there is no re-render between pointerDown and pointerUp
+            ref.current.hitTarget = hitTarget;
             return;
         }
 
@@ -378,6 +381,7 @@ export const useMouse = (
                 rowDrag,
 
                 draggingKnob,
+                hitTarget,
 
                 cellLayout: {pixelToColumn, pixelToRow, getIndentX, getIndentY},
             },
@@ -439,7 +443,11 @@ export const useMouse = (
         if (!xy || !hitTarget) return;
         setHitTarget(null);
 
-        if (hitTarget === getMouseHit(xy)) {
+        // Check hit target rect to see if it is the same as pointerDown
+        // (object identity might have changed due to react re-render)
+        const previousRect = JSON.stringify(hitTarget.rect);
+        const currentRect = JSON.stringify(getMouseHit(xy)?.rect);
+        if (previousRect === currentRect) {
             const {obj} = hitTarget;
             obj.onClick?.(e);
         }


### PR DESCRIPTION
The logic for pointerDown / pointerUp checks to see if the `hitTarget` was the same as before, in order to detect when the user has moved the mouse off the element before lifting the button.

This code assumed `hitTarget` would not change mid-gesture. But due to a react re-render, you might get a different object instance with the same data. To detect this, this PR compares the hitTarget's `rect` by value instead.

I also added an additional fix where, if there is no react re-render at all between pointerDown / pointerUp (slow computer?), the hitTarget is still passed between the two handlers.