### PR TITLE
fix: source data fn is used when copy pasting values instead of edit data fn

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -7,7 +7,8 @@ export const useClipboardCopy = (
     textAreaRef: RefObject<HTMLTextAreaElement>,
     selection: Rectangle,
     editMode: boolean,
-    editData: CellPropertyFunction<string>
+    editData: CellPropertyFunction<string>,
+    sourceData: CellPropertyFunction<string | number | null>
 ) => {
     useLayoutEffect(() => {
         const { current: textArea } = textAreaRef;
@@ -16,7 +17,7 @@ export const useClipboardCopy = (
         if (editMode) return;
         if (isEmptySelection(selection)) return;
 
-        let v = formatSelectionAsTSV(selection, editData);
+        let v = formatSelectionAsTSV(selection, editData, sourceData);
 
         // Bizarre: having only TAB/RETURN characters inside the textarea
         // prevents native auto-scroll. Also bizarre: auto-scroll doesn't work
@@ -95,7 +96,11 @@ export const useClipboardPaste = (
 
 const formatTSV = (rows: string[][]) => rows.map((row) => row.join('\t')).join('\n');
 
-const formatSelectionAsTSV = (selection: Rectangle, editData: CellPropertyFunction<string>) => {
+const formatSelectionAsTSV = (
+    selection: Rectangle,
+    editData: CellPropertyFunction<string>,
+    sourceData: CellPropertyFunction<string | number | null>
+) => {
     if (isEmptySelection(selection)) return '';
 
     let [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
@@ -116,9 +121,9 @@ const formatSelectionAsTSV = (selection: Rectangle, editData: CellPropertyFuncti
         const row: string[] = [];
 
         for (let x = minX; x <= maxX; x++) {
-            const value = editData(x, y);
+            const value = sourceData(x, y);
             if (value !== null && value !== undefined) {
-                row.push(value != null ? value : '');
+                row.push(typeof value === 'number' ? value.toString() : value);
             }
         }
 

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -280,7 +280,7 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
 
     // Textarea is used to hold text to copy, and receives pastes
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
-    useClipboardCopy(textAreaRef, selection, editMode, editData);
+    useClipboardCopy(textAreaRef, selection, editMode, editData, sourceData);
     useClipboardPaste(textAreaRef, selection, changeSelection, props.onChange, cellReadOnly);
 
     const onScroll = useScroll(dataOffset, maxScroll, cellLayout, setDataOffset, setMaxScroll);


### PR DESCRIPTION
This causes problems when using sourceData to pass the id of an row instead of the displayed value.