### PR TITLE
row/column groups

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -16,6 +16,7 @@ import {
     SheetBoxStyle,
     SheetBoxBasic,
     SheetBoxRender,
+    SheetBoxGrouped,
     SheetBoxFormatting,
     SheetBoxVeryBigData,
     SheetBoxCustomInput,
@@ -51,8 +52,8 @@ const App = () => {
                     <h3>Basic spreadsheet</h3>
                     <p>
                         It has all the features you'd expect from the spreadsheet: keyboard navigation, copy cells by
-                        dragging the small square, copy/paste from and to Excel and Google Sheets, resize and reorder columns and
-                        rows.
+                        dragging the small square, copy/paste from and to Excel and Google Sheets, resize and reorder
+                        columns and rows.
                     </p>
                 </div>
             </Wrap>
@@ -86,9 +87,16 @@ const App = () => {
                 </div>
                 <div className="box">
                     <h3>Overlays</h3>
-                    <p>
-                        You can attach HTML overlays to the sheet, for additional controls, notes, etc.
-                    </p>
+                    <p>You can attach HTML overlays to the sheet, for additional controls, notes, etc.</p>
+                </div>
+            </Wrap>
+            <Wrap>
+                <div className="box">
+                    <SheetBoxGrouped />
+                </div>
+                <div className="box">
+                    <h3>Grouped rows and columns</h3>
+                    <p>You can make rows act as a group for drag-and-drop operation.</p>
                 </div>
             </Wrap>
 
@@ -273,8 +281,8 @@ const App = () => {
                     {/* inputComponent */}
                     <h3>Custom input</h3>
                     <p>
-                        By default edit mode turns the cell into a text edit component. But you can send your custom input
-                        component via <Emphased text="inputComponent" /> props. It will be called with{' '}
+                        By default edit mode turns the cell into a text edit component. But you can send your custom
+                        input component via <Emphased text="inputComponent" /> props. It will be called with{' '}
                         <Emphased text="x" />, <Emphased text="y" />, <Emphased text="inputProps" /> and{' '}
                         <Emphased text="commitEditingCell" /> arguments.
                     </p>

--- a/example/src/App.test.js
+++ b/example/src/App.test.js
@@ -1,9 +1,9 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import App from './App'
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
 
 it('renders without crashing', () => {
-  const div = document.createElement('div')
-  ReactDOM.render(<App />, div)
-  ReactDOM.unmountComponentAtNode(div)
-})
+    const div = document.createElement('div');
+    ReactDOM.render(<App />, div);
+    ReactDOM.unmountComponentAtNode(div);
+});

--- a/example/src/components/Footer.js
+++ b/example/src/components/Footer.js
@@ -3,7 +3,9 @@ import React from 'react';
 function Footer() {
     return (
         <div className="footer">
-            <p className="copy">made by <a href="https://www.farseer.io">farseer</a></p>
+            <p className="copy">
+                made by <a href="https://www.farseer.io">farseer</a>
+            </p>
         </div>
     );
 }

--- a/example/src/components/Menu.js
+++ b/example/src/components/Menu.js
@@ -9,10 +9,10 @@ function Menu() {
         var offsetPosition = elementPosition - headerOffset;
 
         window.scrollTo({
-             top: offsetPosition,
-             behavior: "smooth"
+            top: offsetPosition,
+            behavior: 'smooth',
         });
-    }
+    };
 
     return (
         <div className="container blue-bg menu">
@@ -22,10 +22,18 @@ function Menu() {
                     <h2 className="page-title">sheet - happens</h2>
                 </div>
                 <div className="nav">
-                    <div className="nav-item" onClick={() => scrollTo('home')} >home</div>
-                    <div className="nav-item" onClick={() => scrollTo('usage')} >usage</div>
-                    <div className="nav-item" onClick={() => scrollTo('features')} >features</div>
-                    <div className="nav-item" onClick={() => scrollTo('documentation')} >documentation</div>
+                    <div className="nav-item" onClick={() => scrollTo('home')}>
+                        home
+                    </div>
+                    <div className="nav-item" onClick={() => scrollTo('usage')}>
+                        usage
+                    </div>
+                    <div className="nav-item" onClick={() => scrollTo('features')}>
+                        features
+                    </div>
+                    <div className="nav-item" onClick={() => scrollTo('documentation')}>
+                        documentation
+                    </div>
                 </div>
             </div>
         </div>

--- a/example/src/components/SheetBox.js
+++ b/example/src/components/SheetBox.js
@@ -45,7 +45,7 @@ export function useWidthHeightControl(
     initialWidths = [],
     initialHeights = [],
     getColumnOrder = (i: number) => i,
-    getRowOrder = (i: number) => i,
+    getRowOrder = (i: number) => i
 ) {
     const [cellWidth, setCellWidth] = useState(initialWidths);
     const [cellHeight, setCellHeight] = useState(initialHeights);
@@ -95,11 +95,14 @@ export function useOrderControl(initialColumns = [], initialRows = []) {
         const co = [...columnOrder];
 
         const min = indices[0];
-        const n = Math.max(order + indices.length, indices.reduce((a, b) => Math.max(a, b)));
+        const n = Math.max(
+            order + indices.length,
+            indices.reduce((a, b) => Math.max(a, b))
+        );
         while (co.length < n) co.push(co.length);
 
         co.splice(min, indices.length);
-        co.splice(order, 0, ...indices.map(i => getColumnOrder(i)));
+        co.splice(order, 0, ...indices.map((i) => getColumnOrder(i)));
         setColumnOrder(co);
     };
 
@@ -107,11 +110,14 @@ export function useOrderControl(initialColumns = [], initialRows = []) {
         const ro = [...rowOrder];
 
         const min = indices[0];
-        const n = Math.max(order + indices.length, indices.reduce((a, b) => Math.max(a, b)));
+        const n = Math.max(
+            order + indices.length,
+            indices.reduce((a, b) => Math.max(a, b))
+        );
         while (ro.length < n) ro.push(ro.length);
 
         ro.splice(min, indices.length);
-        ro.splice(order, 0, ...indices.map(i => getRowOrder(i)));
+        ro.splice(order, 0, ...indices.map((i) => getRowOrder(i)));
         setRowOrder(ro);
     };
 
@@ -122,7 +128,12 @@ export function SheetBoxHeader() {
     const [data, setData] = useState(initialDataBig);
 
     const { onColumnOrderChange, onRowOrderChange, getColumnOrder, getRowOrder } = useOrderControl();
-    const { onCellWidthChange, onCellHeightChange, cellWidth, cellHeight } = useWidthHeightControl([], [], getColumnOrder, getRowOrder);
+    const { onCellWidthChange, onCellHeightChange, cellWidth, cellHeight } = useWidthHeightControl(
+        [],
+        [],
+        getColumnOrder,
+        getRowOrder
+    );
 
     const onSelectionChanged = (x1, y1, x2, y2) => {};
     const onRightClick = () => {};
@@ -189,7 +200,12 @@ export function SheetBoxHeader() {
 export function SheetBoxBasic() {
     const [data, setData] = useState(JSON.parse(JSON.stringify(initialDataBasic)));
     const { onColumnOrderChange, onRowOrderChange, getColumnOrder, getRowOrder } = useOrderControl();
-    const { onCellWidthChange, onCellHeightChange, cellWidth, cellHeight } = useWidthHeightControl([], [], getColumnOrder, getRowOrder);
+    const { onCellWidthChange, onCellHeightChange, cellWidth, cellHeight } = useWidthHeightControl(
+        [],
+        [],
+        getColumnOrder,
+        getRowOrder
+    );
 
     const onSelectionChanged = (x1, y1, x2, y2) => {};
     const onRightClick = () => {};
@@ -437,7 +453,6 @@ export function SheetBoxFormatting() {
     );
 }
 
-
 export function SheetBoxRender() {
     const [data, setData] = useState(JSON.parse(JSON.stringify(initialDataBasic)));
     const { onCellWidthChange, onCellHeightChange, cellWidth, cellHeight } = useWidthHeightControl();
@@ -461,7 +476,7 @@ export function SheetBoxRender() {
 
     const onChange = (changes) => {
         const newData = [...data];
-        for (const {x, y, value} of changes) {
+        for (const { x, y, value } of changes) {
             if (!newData[y]) {
                 newData[y] = [];
             }
@@ -474,37 +489,32 @@ export function SheetBoxRender() {
         return false;
     };
 
-    const render = ({
-        visibleCells,
-        cellLayout,
-        selection,
-        editMode,
-    }) => {
+    const render = ({ visibleCells, cellLayout, selection, editMode }) => {
         if (editMode) return;
-        
+
         const cell = [1, 2];
         const [anchor] = selection;
-        const noteOpen = (anchor[0] === cell[0] && anchor[1] === cell[1]);
+        const noteOpen = anchor[0] === cell[0] && anchor[1] === cell[1];
 
-        const isCellVisible = (
-            visibleCells.columns.includes(cell[0]) &&
-            visibleCells.rows.includes(cell[1])
-        );
+        const isCellVisible = visibleCells.columns.includes(cell[0]) && visibleCells.rows.includes(cell[1]);
         if (!isCellVisible) return null;
 
         const [, top] = cellLayout.cellToPixel(cell, [0, 0]);
-        const [right, ] = cellLayout.cellToPixel(cell, [1, 1]);
+        const [right] = cellLayout.cellToPixel(cell, [1, 1]);
 
-        const marker = <div
-            style={{
-                position: 'absolute',
-                left: right,
-                top: top,
-                marginLeft: '-12px',
-                borderTop: '12px solid blue',
-                borderLeft: '12px solid transparent',
-                pointerEvents: 'none',
-            }} />
+        const marker = (
+            <div
+                style={{
+                    position: 'absolute',
+                    left: right,
+                    top: top,
+                    marginLeft: '-12px',
+                    borderTop: '12px solid blue',
+                    borderLeft: '12px solid transparent',
+                    pointerEvents: 'none',
+                }}
+            />
+        );
 
         const note = noteOpen ? (
             <div
@@ -520,7 +530,7 @@ export function SheetBoxRender() {
                 Hello world
             </div>
         ) : null;
-        
+
         return (
             <div onPointerDown={(e: any) => e.stopPropagation()}>
                 {note}
@@ -532,7 +542,10 @@ export function SheetBoxRender() {
     return (
         <div className="sheet-box">
             <Sheet
-                selection={[[1, 2], [1, 2]]}
+                selection={[
+                    [1, 2],
+                    [1, 2],
+                ]}
                 onSelectionChanged={onSelectionChanged}
                 onRightClick={onRightClick}
                 columnHeaders={columnHeaders}
@@ -547,6 +560,98 @@ export function SheetBoxRender() {
                 onCellWidthChange={onCellWidthChange}
                 onCellHeightChange={onCellHeightChange}
                 renderInside={render}
+                cacheLayout
+            />
+        </div>
+    );
+}
+
+export function SheetBoxGrouped() {
+    const [data, setData] = useState(initialDataBig);
+
+    const { onColumnOrderChange, onRowOrderChange, getColumnOrder, getRowOrder } = useOrderControl();
+    const { onCellWidthChange, onCellHeightChange, cellWidth, cellHeight } = useWidthHeightControl(
+        [],
+        [],
+        getColumnOrder,
+        getRowOrder
+    );
+
+    const groupKeys = [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 7, 8, 8];
+    const orderedGroupKeys = groupKeys.map((_, i) => groupKeys[getRowOrder(i)]);
+
+    const alternatingGroups = orderedGroupKeys
+        .map((key, i) => key !== orderedGroupKeys[i - 1])
+        .reduce((list, start) => {
+            const last = list.at(-1) ?? 1;
+            const bit = start ? 1 - last : last;
+            list.push(bit);
+            return list;
+        }, []);
+
+    const onSelectionChanged = (x1, y1, x2, y2) => {};
+    const onRightClick = () => {};
+    const columnHeaders = ['A', 'B', 'C'];
+    const cellStyle = (x, y) => {
+        return {
+            fillColor: ['#ffffff', '#e0e0e0'][alternatingGroups[y]],
+        };
+    };
+
+    const rowGroupKeys = (y) => {
+        return orderedGroupKeys[y];
+    };
+
+    const editData = (x, y) => {
+        return data?.[getRowOrder(y)]?.[getColumnOrder(x)];
+    };
+    const displayData = (x, y) => {
+        return data?.[getRowOrder(y)]?.[getColumnOrder(x)];
+    };
+    const sourceData = (x, y) => {
+        return data?.[getRowOrder(y)]?.[getColumnOrder(x)];
+    };
+    const editKeys = (x, y) => {
+        return `${x},${y}`;
+    };
+
+    const onChange = (changes) => {
+        const newData = [...data];
+        for (const change of changes) {
+            const cx = getColumnOrder(change.x);
+            const cy = getRowOrder(change.y);
+            if (!newData[cy]) {
+                newData[cy] = [];
+            }
+            newData[cy][cx] = change.value;
+        }
+        setData(newData);
+    };
+
+    const isReadOnly = (x, y) => {
+        return false;
+    };
+
+    return (
+        <div className="sheet-box">
+            <Sheet
+                onSelectionChanged={onSelectionChanged}
+                onRightClick={onRightClick}
+                columnHeaders={columnHeaders}
+                cellStyle={cellStyle}
+                editData={editData}
+                displayData={displayData}
+                sourceData={sourceData}
+                cellWidth={cellWidth}
+                cellHeight={cellHeight}
+                onChange={onChange}
+                readOnly={isReadOnly}
+                onCellWidthChange={onCellWidthChange}
+                onCellHeightChange={onCellHeightChange}
+                onColumnOrderChange={onColumnOrderChange}
+                onRowOrderChange={onRowOrderChange}
+                rowGroupKeys={rowGroupKeys}
+                editKeys={editKeys}
                 cacheLayout
             />
         </div>
@@ -642,16 +747,14 @@ export function SheetBoxVeryBigData() {
 
     return (
         <>
-            {loadingStatus === 'initial' ?
-                (
-                    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                    <a href="#" onClick={loadClick}>
-                        Load global database of power plants
-                    </a>
-                ) : loadingStatus === 'loading' ? (
-                    'Loading...'
-                ) : null
-            }
+            {loadingStatus === 'initial' ? (
+                // eslint-disable-next-line jsx-a11y/anchor-is-valid
+                <a href="#" onClick={loadClick}>
+                    Load global database of power plants
+                </a>
+            ) : loadingStatus === 'loading' ? (
+                'Loading...'
+            ) : null}
             <div className="sheet-box">
                 <Sheet
                     cellStyle={cellStyle}

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -195,7 +195,7 @@ p {
 .sheet-box {
     position: relative;
     background-color: #fff;
-    min-height: 330px;
+    height: 330px;
     width: 100%;
     color: #160901;
     flex-grow: 1;

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,7 +1,7 @@
-import './index.css'
+import './index.css';
 
-import React from 'react'
-import ReactDOM from 'react-dom'
-import App from './App'
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'))
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,7 +16,7 @@ export const MAX_XY: XY = [MAX_SEARCHABLE_INDEX, MAX_SEARCHABLE_INDEX];
 
 export const COLORS = {
     selectionBorder: '#1a66ff',
-    selectionBackground: '#e8f0ff',
+    selectionBackground: '#d8e6ff80',
 
     gridLine: '#0000001f',
 

--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -72,16 +72,34 @@ export const isPointInsideSelection = (selection: Rectangle, point: XY) => {
 
 // Normalize rectangle to min/max pair
 export const normalizeSelection = (selection: Rectangle): Rectangle => {
-    let [[left, top], [right, bottom]] = selection;
-    if (left > right) {
-        [left, right] = [right, left];
-    }
-    if (top > bottom) {
-        [top, bottom] = [bottom, top];
-    }
+    const [anchor, head] = selection;
+    const [ax, ay] = anchor;
+    const [hx, hy] = head;
+
+    const left = Math.min(ax, hx);
+    const right = Math.max(ax, hx);
+    const top = Math.min(ay, hy);
+    const bottom = Math.max(ay, hy);
 
     return [
         [left, top],
         [right, bottom],
+    ];
+};
+
+// Orient normalized rectangle to match existing orientation
+export const orientSelection = (normalized: Rectangle, to: Rectangle): Rectangle => {
+    const [[left, top], [right, bottom]] = normalized;
+
+    const [anchor, head] = to;
+    const [ax, ay] = anchor;
+    const [hx, hy] = head;
+
+    const swapX = (ax - hx || 1) * (left - right || 1) < 0;
+    const swapY = (ay - hy || 1) * (top - bottom || 1) < 0;
+
+    return [
+        [swapX ? right : left, swapY ? bottom : top],
+        [swapX ? left : right, swapY ? top : bottom],
     ];
 };

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,0 +1,71 @@
+import { Rectangle, RowOrColumnPropertyFunction } from './types';
+import { normalizeSelection, orientSelection } from './coordinate';
+
+const LIMIT = 1000;
+
+const scanGroup = (
+    keys: RowOrColumnPropertyFunction<string | number | null>,
+    index: number,
+    direction: number,
+    match: string | number | null
+) => {
+    if (match == null) return index;
+
+    let i = 0;
+    const limit = direction > 0 ? LIMIT : Math.min(LIMIT, index + 1);
+    for (; i < limit; i++) {
+        if (keys(index + i * direction) !== match) break;
+    }
+    return index + (i - 1) * direction;
+};
+
+export const expandSelectionToColumnGroups = (
+    selection: Rectangle,
+    columnGroupKeys: RowOrColumnPropertyFunction<string | number | null>
+) => {
+    const [[left, top], [right, bottom]] = normalizeSelection(selection);
+
+    const leftKey = columnGroupKeys(left);
+    const rightKey = columnGroupKeys(right);
+
+    const startColumn = scanGroup(columnGroupKeys, left, -1, leftKey);
+    const endColumn = scanGroup(columnGroupKeys, right, 1, rightKey);
+
+    const expanded: Rectangle = [
+        [startColumn, top],
+        [endColumn, bottom],
+    ];
+    const oriented = orientSelection(expanded, selection);
+
+    return oriented;
+};
+
+export const expandSelectionToRowGroups = (
+    selection: Rectangle,
+    rowGroupKeys: RowOrColumnPropertyFunction<string | number | null>
+) => {
+    const [[left, top], [right, bottom]] = normalizeSelection(selection);
+
+    const topKey = rowGroupKeys(top);
+    const bottomKey = rowGroupKeys(bottom);
+
+    const startRow = scanGroup(rowGroupKeys, top, -1, topKey);
+    const endRow = scanGroup(rowGroupKeys, bottom, 1, bottomKey);
+
+    const expanded: Rectangle = [
+        [left, startRow],
+        [right, endRow],
+    ];
+    const oriented = orientSelection(expanded, selection);
+
+    return oriented;
+};
+
+export const isBoundaryInsideGroup = (
+    index: number,
+    rowOrColumnGroupKeys: RowOrColumnPropertyFunction<string | number | null>
+) => {
+    const before = rowOrColumnGroupKeys(index - 1);
+    const after = rowOrColumnGroupKeys(index);
+    return before != null && after != null && before === after;
+};


### PR DESCRIPTION
sheet
- add `rowGroupKeys` / `columnGroupKeys` to indicate which rows/cols are grouped together
- grouping is for whole row/column selection only
- can only drag / drop to group boundaries
- fix memo bug

examples
- add grouped example sheet box
- fix example height CSS to match new styles
- run prettier on examples

<img width="1268" alt="Screenshot 2023-12-15 at 17 32 19" src="https://github.com/farseerdev/sheet-happens/assets/172808/b4ff74a6-97d0-4ada-8626-824fcc1a85d4">
