### PR TITLE
auto-scroll when table gets smaller

### DIFF
--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -130,3 +130,9 @@ export const orientSelection = (normalized: Rectangle, to: Rectangle): Rectangle
         [swapX ? left : right, swapY ? top : bottom],
     ];
 };
+
+// Clip rectangle to max range
+export const clipSelection = (selection: Rectangle, max: XY): Rectangle => {
+    const [anchor, head] = selection;
+    return [minXY(anchor, max), minXY(head, max)];
+};

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -240,7 +240,7 @@ export const useMouse = (
                                                   selectedColumnGroups.has(columnGroupKeys(index))
                                               )
                                             : []),
-                                    ]).values(),
+                                    ]).values()
                                 );
                                 indices.sort((a, b) => a - b);
 
@@ -339,7 +339,7 @@ export const useMouse = (
                                                   .map((_, i) => i)
                                                   .filter((index) => selectedRowGroups.has(rowGroupKeys(index)))
                                             : []),
-                                    ]).values(),
+                                    ]).values()
                                 );
                                 indices.sort((a, b) => a - b);
 


### PR DESCRIPTION
- add a `maxRows` and `maxColumns` prop
- if the table gets smaller, clip the selection to the given range (user can still go outside)
- when auto-scrolling, avoid showing past the end of the table

Goal is to provide a nicer experience if e.g. the table gets smaller, by scrolling so that the bottom right cell is in the bottom right.