### PR TITLE
Steven/scroll click fixes

### DIFF
--- a/example/src/components/SheetBox.js
+++ b/example/src/components/SheetBox.js
@@ -51,31 +51,34 @@ export function useWidthHeightControl(
     const [cellHeight, setCellHeight] = useState(initialHeights);
 
     const onCellWidthChange = (indices, newWidth) => {
-        const cw = [...cellWidth];
-        for (const order of indices) {
-            const idx = getColumnOrder(order);
-            if (idx > cw.length) {
-                for (let i = cw.length; i <= idx; i++) {
-                    cw.push(DEFAULT_CELL_WIDTH);
+        setCellWidth((cellWidth) => {
+            const cw = [...cellWidth];
+            for (const order of indices) {
+                const idx = getColumnOrder(order);
+                if (idx > cw.length) {
+                    for (let i = cw.length; i <= idx; i++) {
+                        cw.push(DEFAULT_CELL_WIDTH);
+                    }
                 }
+                cw[idx] = newWidth;
             }
-            cw[idx] = newWidth;
-        }
-        setCellWidth(cw);
+            return cw;
+        });
     };
 
     const onCellHeightChange = (indices, newHeight) => {
-        const ch = [...cellHeight];
-        for (const order of indices) {
-            const idx = getRowOrder(order);
-            if (idx > ch.length) {
-                for (let i = ch.length; i <= idx; i++) {
-                    ch.push(DEFAULT_CELL_HEIGHT);
+        setCellHeight((cellHeight) => {
+            const ch = [...cellHeight];
+            for (const order of indices) {
+                const idx = getRowOrder(order);
+                if (idx > ch.length) {
+                    for (let i = ch.length; i <= idx; i++) {
+                        ch.push(DEFAULT_CELL_HEIGHT);
+                    }
                 }
+                ch[idx] = newHeight;
             }
-            ch[idx] = newHeight;
-        }
-        setCellHeight(ch);
+        });
     };
 
     const cw = (x: number) => cellWidth[getColumnOrder(x)] ?? DEFAULT_CELL_WIDTH;

--- a/src/autosize.ts
+++ b/src/autosize.ts
@@ -1,0 +1,47 @@
+import { useCallback, useMemo } from 'react';
+import { DEFAULT_CELL_STYLE } from './constants';
+import { resolveCellStyle } from './style';
+import { CellPropertyFunction, CellContentType, Style } from './types';
+
+export const useAutoSizeColumn = (
+    rows: number[],
+    displayData: CellPropertyFunction<CellContentType>,
+    cellStyle: CellPropertyFunction<Style>
+) => {
+    const context = useMemo(() => document.createElement('canvas').getContext('2d'), []);
+
+    const getAutoSizeWidth = useCallback(
+        (x: number) => {
+            if (!context) return 0;
+
+            let maxWidth = 0;
+            for (const y of rows) {
+                const cellContent = displayData(x, y);
+                if (cellContent != null) {
+                    const style = cellStyle(x, y);
+
+                    const finalStyle = resolveCellStyle(style, DEFAULT_CELL_STYLE);
+                    context.fillStyle = finalStyle.color;
+                    context.font = finalStyle.weight + ' ' + finalStyle.fontSize + 'px ' + finalStyle.fontFamily;
+
+                    if (typeof cellContent === 'string' || typeof cellContent === 'number') {
+                        const { width } = context.measureText(cellContent.toString());
+                        maxWidth = Math.max(maxWidth, width + finalStyle.marginLeft + finalStyle.marginRight);
+                    } else if (typeof cellContent === 'object') {
+                        for (const obj of cellContent.items) {
+                            if (typeof obj.content === 'string' || typeof obj.content === 'number') {
+                                const { width } = context.measureText(obj.content.toString());
+                                maxWidth = Math.max(maxWidth, obj.x + width);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return Math.ceil(maxWidth);
+        },
+        [context]
+    );
+
+    return getAutoSizeWidth;
+};

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -143,6 +143,12 @@ export const useMouse = (
 
         const rect = e.target.getBoundingClientRect();
         const xy: XY = [e.clientX - rect.left, e.clientY - rect.top];
+
+        // Ignore clicks on scrollbar
+        if (xy[0] > e.target.clientWidth || xy[1] > e.target.clientHeight) {
+            return null;
+        }
+
         return xy;
     }, []);
 
@@ -611,10 +617,10 @@ export const useMouse = (
                 },
             } = ref;
 
+            window.document.body.style.cursor = 'auto';
+
             const xy = getMousePosition(e);
             if (!xy) return;
-
-            window.document.body.style.cursor = 'auto';
 
             const hitTarget = getMouseHit(xy);
             if (hitTarget) {

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -58,6 +58,7 @@ import {
 } from './coordinate';
 import { useMouse } from './mouse';
 import { useScroll, scrollToCell } from './scroll';
+import { useAutoSizeColumn } from './autosize';
 import { useClipboardCopy, useClipboardPaste } from './clipboard';
 import { makeLayoutCache, makeCellLayout } from './layout';
 import { createCellProp, createRowOrColumnProp, findInDisplayData } from './props';
@@ -331,6 +332,8 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
 
     const onScroll = useScroll(dataOffset, maxScroll, cellLayout, setDataOffset, setMaxScroll);
 
+    const getAutoSizeWidth = useAutoSizeColumn(visibleCells.rows, displayData, cellStyle);
+
     const { mouseHandlers, knobPosition } = useMouse(
         hitmapRef,
         selection,
@@ -353,6 +356,8 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
         rowGroupKeys,
         selectedColumnGroups,
         selectedRowGroups,
+
+        getAutoSizeWidth,
 
         startEditingCell,
         commitEditingCell,


### PR DESCRIPTION
- ignore mouse clicks on scrollbar
- double click column resizer to auto-size to fit (visible rows only, works like google sheets for multiselection)
