### PR TITLE
use clipboard API and make payload injectable

### DIFF
--- a/example/src/components/Code.js
+++ b/example/src/components/Code.js
@@ -9,94 +9,6 @@ xcode.hljs.overflow = 'auto';
 xcode.hljs.borderRadius = '3px';
 xcode.hljs.fontSize = '14px';
 
-function Code() {
-    return (
-        <SyntaxHighlighter language="javascript" style={xcode}>
-            {`function SheetBox() {
-    const [data, setData] = useState(initialData);
-    const [cellWidth, setCellWidth] = useState([]);
-    const [cellHeight, setCellHeight] = useState([]);
-
-    const onSelectionChanged = (x1, y1, x2, y2) => {};
-    const onRightClick = () => {};
-    const columnHeaders = ['A', 'B', 'C'];
-    const cellStyle = (x, y) => {
-        return {};
-    };
-    const editData = (x, y) => {
-        return data?.[y]?.[x];
-    };
-    const displayData = (x, y) => {
-        return data?.[y]?.[x];
-    };
-    const sourceData = (x, y) => {
-        return data?.[y]?.[x];
-    };
-
-    const onChange = (changes) => {
-        const newData = [...data];
-        for (const change of changes) {
-            if (!newData[change.y]) {
-                newData[change.y] = [];
-            }
-            newData[change.y][change.x] = change.value;
-        }
-        setData(newData);
-    };
-
-    const isReadOnly = (x, y) => {
-        return false;
-    };
-
-    const onCellWidthChange = (columnIdx, newWidth) => {
-        const cw = [...cellWidth];
-        if (columnIdx > cw.length) {
-            for (let i = cw.length; i <= columnIdx; i++) {
-                cw.push(100);
-            }
-        }
-        cw[columnIdx] = newWidth;
-        setCellWidth(cw);
-    };
-    const onCellHeightChange = (rowIdx, newHeight) => {
-        const ch = [...cellHeight];
-        if (rowIdx > ch.length) {
-            for (let i = ch.length; i <= rowIdx; i++) {
-                ch.push(22);
-            }
-        }
-        ch[rowIdx] = newHeight;
-        setCellHeight(ch);
-    };
-
-    return (
-        <div className="sheet-box">
-            <Sheet
-                onSelectionChanged={onSelectionChanged}
-                onRightClick={onRightClick}
-                columnHeaders={columnHeaders}
-                cellStyle={cellStyle}
-                editData={editData}
-                displayData={displayData}
-                sourceData={sourceData}
-                cellWidth={cellWidth}
-                cellHeight={cellHeight}
-                onChange={onChange}
-                readOnly={isReadOnly}
-                onCellWidthChange={onCellWidthChange}
-                onCellHeightChange={onCellHeightChange}
-                freezeColumns={0}
-                freezeRows={0}
-            />
-        </div>
-    );
-}`}
-        </SyntaxHighlighter>
-    );
-}
-
-export default Code;
-
 export function SourceDisplayDataCode() {
     let xcode2 = { ...xcode };
     xcode2.hljs.height = '100%';
@@ -206,15 +118,20 @@ const cellStyle = (x, y) => {
 
 const [cellWidth, setCellWidth] = useState([]);
 
-const onCellWidthChange = (columnIdx, newWidth) => {
-    const cw = [...cellWidth];
-    if (columnIdx > cw.length) {
-        for (let i = cw.length; i <= columnIdx; i++) {
-            cw.push(100);
+const onCellWidthChange = (indices, newWidths) => {
+    setCellWidth((cellWidth) => {
+        const cw = [...cellWidth];
+        for (const [i, order] of indices.entries()) {
+            const idx = getColumnOrder(order);
+            if (idx > cw.length) {
+                for (let i = cw.length; i <= idx; i++) {
+                    cw.push(DEFAULT_CELL_WIDTH);
+                }
+            }
+            cw[idx] = newWidths[i];
         }
-    }
-    cw[columnIdx] = newWidth;
-    setCellWidth(cw);
+        return cw;
+    });
 };
 
 return (

--- a/example/src/components/SheetBox.js
+++ b/example/src/components/SheetBox.js
@@ -78,6 +78,7 @@ export function useWidthHeightControl(
                 }
                 ch[idx] = newHeight;
             }
+            return ch;
         });
     };
 
@@ -197,6 +198,7 @@ export function SheetBoxHeader() {
                 onColumnOrderChange={onColumnOrderChange}
                 onRowOrderChange={onRowOrderChange}
                 editKeys={editKeys}
+                autoFocus
                 cacheLayout
             />
         </div>

--- a/example/src/components/SheetBox.js
+++ b/example/src/components/SheetBox.js
@@ -50,33 +50,33 @@ export function useWidthHeightControl(
     const [cellWidth, setCellWidth] = useState(initialWidths);
     const [cellHeight, setCellHeight] = useState(initialHeights);
 
-    const onCellWidthChange = (indices, newWidth) => {
+    const onCellWidthChange = (indices, newWidths) => {
         setCellWidth((cellWidth) => {
             const cw = [...cellWidth];
-            for (const order of indices) {
+            for (const [i, order] of indices.entries()) {
                 const idx = getColumnOrder(order);
                 if (idx > cw.length) {
                     for (let i = cw.length; i <= idx; i++) {
                         cw.push(DEFAULT_CELL_WIDTH);
                     }
                 }
-                cw[idx] = newWidth;
+                cw[idx] = newWidths[i];
             }
             return cw;
         });
     };
 
-    const onCellHeightChange = (indices, newHeight) => {
+    const onCellHeightChange = (indices, newHeights) => {
         setCellHeight((cellHeight) => {
             const ch = [...cellHeight];
-            for (const order of indices) {
+            for (const [i, order] of indices.entries()) {
                 const idx = getRowOrder(order);
                 if (idx > ch.length) {
                     for (let i = ch.length; i <= idx; i++) {
                         ch.push(DEFAULT_CELL_HEIGHT);
                     }
                 }
-                ch[idx] = newHeight;
+                ch[idx] = newHeights[i];
             }
             return ch;
         });

--- a/src/autosize.ts
+++ b/src/autosize.ts
@@ -44,7 +44,7 @@ export const useAutoSizeColumn = (
                         }
 
                         if (obj.horizontalAlign === 'right') {
-                            extraWidth += width;
+                            extraWidth += style.textAlign === 'right' ? width * 2 : width;
                         } else {
                             maxWidth = Math.max(maxWidth, width);
                         }

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -38,10 +38,12 @@ export const useClipboardTable = () => {
 
     useLayoutEffect(() => {
         const softRefresh = async () => {
-            const status = await navigator.permissions.query({ name: 'clipboard-read' as any });
-            if (status.state !== 'granted') return;
+            try {
+                const status = await navigator.permissions.query({ name: 'clipboard-read' as any });
+                if (status.state !== 'granted') return;
 
-            hardRefresh();
+                hardRefresh();
+            } catch (e) {}
         };
 
         const hardRefresh = async () => {

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,102 +1,283 @@
-import { CellPropertyFunction, Change, ParsedChange, Rectangle } from './types';
-import { RefObject, useLayoutEffect, useEffect } from 'react';
+import { ClipboardPayload, CellPropertyFunction, Change, Rectangle } from './types';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { findApproxMaxEditDataIndex } from './props';
-import { normalizeSelection, isMaybeRowSelection, isMaybeColumnSelection, isEmptySelection } from './coordinate';
+import {
+    normalizeSelection,
+    isMaybeRowSelection,
+    isMaybeColumnSelection,
+    isEmptySelection,
+    addXY,
+    forSelectionRows,
+    forSelectionColumns,
+} from './coordinate';
 
-export const useClipboardCopy = (
-    textAreaRef: RefObject<HTMLTextAreaElement>,
-    selection: Rectangle,
-    editMode: boolean,
-    editData: CellPropertyFunction<string>
-) => {
-    useLayoutEffect(() => {
-        const { current: textArea } = textAreaRef;
-        if (!textArea) return;
+// Type missing from TS <=4.3
+interface ClipboardItem {
+    readonly types: string[];
+    readonly presentationStyle: 'unspecified' | 'inline' | 'attachment';
+    getType(): Promise<Blob>;
+}
 
-        if (editMode) return;
-        if (isEmptySelection(selection)) return;
-
-        let v = formatSelectionAsTSV(selection, editData);
-
-        // Bizarre: having only TAB/RETURN characters inside the textarea
-        // prevents native auto-scroll. Also bizarre: auto-scroll doesn't work
-        // if we don't focus the textarea at all.
-        if (v.match(/^[\t\n]*$/)) {
-            v = ' ' + v;
-        }
-        textArea.value = v;
-    }, [selection, editMode, editData, textAreaRef]);
-
-    useLayoutEffect(() => {
-        const { current: textArea } = textAreaRef;
-        if (!textArea) return;
-
-        const focus = () => {
-            textArea.focus({ preventScroll: true });
-            textArea.select();
-        };
-
-        if (editMode) return;
-        if (document.activeElement === textArea) return;
-
-        const activeTagName = (document as any).activeElement.tagName.toLowerCase();
-        if (
-            !(
-                (activeTagName === 'div' && (document as any).activeElement.contentEditable === 'true') ||
-                activeTagName === 'input' ||
-                activeTagName === 'textarea' ||
-                activeTagName === 'select'
-            )
-        ) {
-            focus();
-        }
-    });
+declare var ClipboardItem: {
+    prototype: ClipboardItem;
+    new (itemData: any): ClipboardItem;
 };
 
-export const useClipboardPaste = (
-    textAreaRef: RefObject<HTMLTextAreaElement>,
-    selection: Rectangle,
-    onSelectionChange?: (selection: Rectangle) => void,
-    onChange?: (changes: Array<Change>) => void,
-    isReadOnly?: CellPropertyFunction<boolean>
-) => {
-    useEffect(() => {
-        const onPaste = (e: any) => {
-            const { current: textArea } = textAreaRef;
-            if (!textArea) return;
+export type ClipboardTable<T = any> = {
+    rows: string[][];
+    payload?: ClipboardPayload<T>;
+};
 
-            if (e.target !== textArea) return;
-            e.preventDefault();
+const EMPTY_TABLE: ClipboardTable = { rows: [] };
 
-            const clipboardData = e.clipboardData || (window as any).clipboardData;
-            const types = clipboardData.types;
+// Access clipboard as HTML table + JSON payload.
+// Provide peek access to clipboard if permission granted.
+// Ask permission on first copy.
+export const useClipboardTable = () => {
+    const [peek, setPeek] = useState<ClipboardTable | null>();
 
-            let parsed;
-            if (types.includes('text/html')) {
-                const pastedHtml = clipboardData.getData('text/html');
-                parsed = parsePastedHtml(selection, pastedHtml, isReadOnly);
-            } else if (types.includes('text/plain')) {
-                const text = clipboardData.getData('text/plain');
-                parsed = parsePastedText(selection, text, isReadOnly);
-            }
-            if (!parsed) return;
+    useLayoutEffect(() => {
+        const softRefresh = async () => {
+            const status = await navigator.permissions.query({ name: 'clipboard-read' as any });
+            if (status.state !== 'granted') return;
 
-            const { selection: s, changes } = parsed;
-            onChange?.(changes);
-            onSelectionChange?.(s);
+            hardRefresh();
         };
 
-        window.document.addEventListener('paste', onPaste);
+        const hardRefresh = async () => {
+            try {
+                const items = await (navigator.clipboard as any).read();
+                const [item] = items;
+                if (item) {
+                    const peek = await parseClipboardTable(item);
+                    setPeek(peek);
+                } else {
+                    setPeek(EMPTY_TABLE);
+                }
+            } catch (e) {}
+        };
+
+        const delayedRefresh = () => setTimeout(hardRefresh);
+
+        window.document.addEventListener('cut', delayedRefresh);
+        window.document.addEventListener('copy', delayedRefresh);
+        window.document.addEventListener('focus', softRefresh);
+
+        softRefresh();
+
         return () => {
-            window.document.removeEventListener('paste', onPaste);
+            window.document.removeEventListener('cut', delayedRefresh);
+            window.document.removeEventListener('copy', delayedRefresh);
+            window.document.removeEventListener('focus', softRefresh);
         };
-    }, [textAreaRef, selection]);
+    }, []);
+
+    const canPaste = useCallback(
+        // Peek may not be available, allow paste attempt.
+        () => !!(peek == null || peek.rows?.length),
+        [peek]
+    );
+
+    return {
+        peek,
+        canPaste,
+        copyTable: copyClipboardTable,
+        pasteTable: pasteClipboardTable,
+    };
 };
 
-const formatTSV = (rows: string[][]) => rows.map((row) => row.join('\t')).join('\n');
+// Sheet clipboard with payload-handler injected
+export const useClipboardAPI = <T = any>(
+    selection: Rectangle,
+    editData: CellPropertyFunction<string>,
+    cellReadOnly: CellPropertyFunction<boolean>,
+    addListener: boolean,
 
-const formatSelectionAsTSV = (selection: Rectangle, editData: CellPropertyFunction<string>) => {
-    if (isEmptySelection(selection)) return '';
+    onSelectionChange?: (selection: Rectangle) => void,
+    onChange?: (changes: Change[]) => void,
+    onCopy?: (selection: Rectangle, rows: string[][], cut: boolean) => ClipboardPayload<T> | null | undefined,
+    onPaste?: (
+        selection: Rectangle,
+        rows: string[][],
+        payload?: ClipboardPayload<T>
+    ) => boolean | null | undefined | Promise<boolean | null | undefined>
+) => {
+    const { canPaste, copyTable, pasteTable } = useClipboardTable();
+
+    const pasteIntoSelection = useCallback(
+        async (selection: Rectangle, table: ClipboardTable) => {
+            const { rows, payload } = table;
+            const [min] = normalizeSelection(selection);
+            const [minX, minY] = min;
+
+            const left = Math.max(0, minX);
+            const top = Math.max(0, minY);
+
+            const width = rows.reduce((a, b) => Math.max(a, b.length), 0);
+            const height = rows.length;
+
+            const newSelection: Rectangle = [min, addXY(min, [width - 1, height - 1])];
+
+            const shouldPaste = await onPaste?.(newSelection, rows, payload);
+            if (shouldPaste !== false) {
+                const changes = rows
+                    .flatMap((row, j) =>
+                        row.map((value, i) => {
+                            const x = left + i;
+                            const y = top + j;
+                            return !cellReadOnly?.(x, y) ? { x, y, value } : null;
+                        })
+                    )
+                    .filter((change) => !!change) as Change[];
+
+                onChange?.(changes);
+                onSelectionChange?.(newSelection);
+            }
+        },
+        [onChange, onSelectionChange, cellReadOnly]
+    );
+
+    // Imperative API
+    const copySelection = useCallback(
+        async (selection: Rectangle, cut: boolean = false) => {
+            const rows = formatSelectionAsRows(selection, editData);
+            const payload = onCopy?.(selection, rows, cut);
+
+            copyTable(rows, payload);
+
+            if (payload?.cut ?? cut) {
+                const changes: Change[] = [];
+                forSelectionRows(selection)((y: number) => {
+                    forSelectionColumns(selection)((x: number) => {
+                        if (!cellReadOnly?.(x, y)) {
+                            const change = { x, y, value: '' };
+                            changes.push(change);
+                        }
+                    });
+                });
+                onChange?.(changes);
+            }
+        },
+        [onCopy, onChange, cellReadOnly]
+    );
+
+    const pasteSelection = useCallback(
+        async (selection: Rectangle) => {
+            const table = await pasteTable();
+            if (table) pasteIntoSelection(selection, table);
+        },
+        [pasteIntoSelection]
+    );
+
+    // Event handlers
+    const onClipboardCopy = (cut: boolean) => {
+        if (isEmptySelection(selection)) return;
+        return copySelection(selection, cut);
+    };
+
+    const onClipboardPaste = async (e: any) => {
+        e.preventDefault();
+
+        const clipboardData = e.clipboardData || (window as any).clipboardData;
+        const table = await parseClipboardTable(clipboardData);
+        if (table) pasteIntoSelection(selection, table);
+    };
+
+    useLayoutEffect(() => {
+        if (!addListener) return;
+
+        // Use onpaste event when we can because it has more browser support
+        window.document.addEventListener('paste', onClipboardPaste);
+        return () => {
+            window.document.removeEventListener('paste', onClipboardPaste);
+        };
+    });
+
+    const clipboardApi = useMemo(
+        () => ({
+            copySelection,
+            pasteSelection,
+            canPasteSelection: canPaste,
+        }),
+        [copySelection, pasteSelection, canPaste]
+    );
+
+    return { clipboardApi, onClipboardCopy, onClipboardPaste };
+};
+
+const copyClipboardTable = async (rows: string[][], payload?: ClipboardPayload<any> | null) => {
+    const text = formatRowsAsTSV(rows);
+    const html = formatRowsAsHTML(rows, payload ?? undefined);
+
+    await (navigator.clipboard as any).write([
+        new ClipboardItem({
+            'text/html': new Blob([html], { type: 'text/html' }),
+            'text/plain': new Blob([text], { type: 'text/plain' }),
+        }),
+    ]);
+
+    const event = new Event('copy');
+    document.dispatchEvent(event);
+};
+
+const pasteClipboardTable = async () => {
+    const items = await (navigator.clipboard as any).read();
+    const [item] = items;
+    if (!item) return;
+
+    return parseClipboardTable(item);
+};
+
+const parseClipboardTable = async (item: ClipboardItem | DataTransfer): Promise<ClipboardTable | null> => {
+    // Work with both clipboard API (ClipboardItem) and onpaste event (DataTransfer)
+    const has = (type: string) => {
+        return item.types.includes(type);
+    };
+
+    const get = (type: string) => {
+        if ('getData' in item) return item.getData(type);
+        else if ('getType' in item) return (item as any).getType(type).then((blob: Blob) => blob.text());
+        return '';
+    };
+
+    let rows, payload;
+    if (has('text/html')) {
+        const pastedHtml = await get('text/html');
+        ({ rows, payload } = parsePastedHtml(pastedHtml));
+    } else if (has('text/plain')) {
+        const text = await get('text/plain');
+        rows = parsePastedText(text);
+    }
+    if (!rows) return { rows: [] };
+
+    return { rows, payload };
+};
+
+const formatRowsAsTSV = (rows: string[][]) => rows.map((row) => row.join('\t')).join('\n');
+
+const formatRowsAsHTML = (rows: string[][], payload?: ClipboardPayload<any>) => {
+    const trs = rows
+        .map((row) => {
+            const tds = row.map(formatTextAsHTML).map((cell) => `<td>${cell}</td>`);
+            return tds.join('');
+        })
+        .map((row) => `<tr>${row}</tr>`)
+        .join('\n');
+
+    const table = `<table>${trs}</table>`;
+
+    if (payload) {
+        const extra = `<SheetHappens payload="${formatTextAsHTML(JSON.stringify(payload))}"></SheetHappens>`;
+        return extra + table;
+    }
+
+    return table;
+};
+
+const formatTextAsHTML = (s: string) => s.replace(/[&"'<>]/g, (i) => `&#${i.charCodeAt(0)};`);
+
+const formatSelectionAsRows = (selection: Rectangle, editData: CellPropertyFunction<string>) => {
+    if (isEmptySelection(selection)) return [];
 
     let [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
     if (isMaybeRowSelection(selection)) {
@@ -125,117 +306,80 @@ const formatSelectionAsTSV = (selection: Rectangle, editData: CellPropertyFuncti
         rows.push(row);
     }
 
-    return formatTSV(rows);
+    return rows;
 };
 
-const findTable = (element: any): any => {
+const findTag = (element: any, tagName: string): any => {
     for (const child of element.children) {
-        if (child.nodeName === 'TABLE') {
+        if (child.nodeName === tagName) {
             return child;
         }
-        const maybeTable = findTable(child);
-        if (maybeTable) {
-            return maybeTable;
+        const maybeTag = findTag(child, tagName);
+        if (maybeTag) {
+            return maybeTag;
         }
     }
 };
 
 const parsePastedHtml = (
-    selection: Rectangle,
-    html: string,
-    isReadOnly?: CellPropertyFunction<boolean>
-): ParsedChange | null => {
+    html: string
+): {
+    rows: string[][];
+    payload: any;
+} => {
     const div = document.createElement('div');
     div.innerHTML = html.trim();
 
-    const [[minX, minY]] = normalizeSelection(selection);
-    let left = isMaybeRowSelection(selection) ? 0 : minX;
-    let top = isMaybeColumnSelection(selection) ? 0 : minY;
+    const rows = [];
+    let payload: any = undefined;
 
-    const changes = [];
-
-    const tableNode = findTable(div);
-    if (!tableNode) {
-        return null;
+    const sheetNode = findTag(div, 'SHEETHAPPENS');
+    if (sheetNode) {
+        const json = sheetNode.getAttribute('payload');
+        try {
+            payload = JSON.parse(json);
+        } catch (e) {}
     }
 
-    let right = left;
-    let bottom = top;
-
-    let y = top;
-    for (const tableChild of tableNode.children) {
-        if (tableChild.nodeName === 'TBODY') {
-            for (const tr of tableChild.children) {
-                let x = left;
-                if (tr.nodeName === 'TR') {
-                    for (const td of tr.children) {
-                        if (td.nodeName === 'TD') {
-                            let str: string = '';
-                            if (td.children.length !== 0 && td.children[0].nodeName === 'P') {
-                                const p = td.children[0];
-                                if (p.children.length !== 0 && p.children[0].nodeName === 'FONT') {
-                                    str = p.children[0].textContent.trim();
+    const tableNode = findTag(div, 'TABLE');
+    if (tableNode) {
+        for (const tableChild of tableNode.children) {
+            if (tableChild.nodeName === 'TBODY') {
+                for (const tr of tableChild.children) {
+                    if (tr.nodeName === 'TR') {
+                        const row = [];
+                        for (const td of tr.children) {
+                            if (td.nodeName === 'TD') {
+                                let str: string = '';
+                                if (td.children.length !== 0 && td.children[0].nodeName === 'P') {
+                                    const p = td.children[0];
+                                    if (p.children.length !== 0 && p.children[0].nodeName === 'FONT') {
+                                        str = p.children[0].textContent.trim();
+                                    } else {
+                                        str = p.textContent.trim();
+                                    }
                                 } else {
-                                    str = p.textContent.trim();
+                                    str = td.textContent.trim();
                                 }
-                            } else {
-                                str = td.textContent.trim();
-                            }
-                            str = str.replaceAll('\n', '');
-                            str = str.replaceAll(/\s\s+/g, ' ');
+                                str = str.replaceAll('\n', '');
+                                str = str.replaceAll(/\s\s+/g, ' ');
 
-                            if (!isReadOnly?.(x, y)) changes.push({ x, y, value: str });
-                            x++;
+                                row.push(str);
+                            }
                         }
+                        rows.push(row);
                     }
-                    y++;
                 }
-                right = Math.max(right, x - 1);
             }
         }
     }
-    bottom = Math.max(top, y - 1);
 
     return {
-        selection: [
-            [left, top],
-            [right, bottom],
-        ],
-        changes,
+        rows,
+        payload,
     };
 };
 
-const parsePastedText = (
-    selection: Rectangle,
-    text: string,
-    isReadOnly?: CellPropertyFunction<boolean>
-): ParsedChange => {
-    const [[minX, minY]] = normalizeSelection(selection);
-    let left = isMaybeRowSelection(selection) ? 0 : minX;
-    let top = isMaybeColumnSelection(selection) ? 0 : minY;
-
-    const rows = text.split(/\r?\n/);
-    let right = left;
-    let bottom = top + rows.length - 1;
-
-    const changes = [];
-    for (let y = 0; y < rows.length; y++) {
-        const cols = rows[y].split('\t');
-        right = Math.max(right, left + cols.length - 1);
-
-        for (let x = 0; x < cols.length; x++) {
-            const X = left + x;
-            const Y = top + y;
-
-            if (!isReadOnly?.(X, Y)) changes.push({ x: X, y: Y, value: cols[x] });
-        }
-    }
-
-    return {
-        selection: [
-            [left, top],
-            [right, bottom],
-        ],
-        changes,
-    };
+const parsePastedText = (text: string): string[][] => {
+    return text.split(/\r?\n/).map((line) => line.split('\t'));
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const INITIAL_MAX_SCROLL: XY = [2000, 1000];
 
 export const ORIGIN: XY = [0, 0];
 export const ONE_ONE: XY = [1, 1];
+export const NEG_NEG: XY = [-1, -1];
 
 export const NO_CELL: XY = [-1, -1];
 export const NO_SELECTION: Rectangle = [NO_CELL, NO_CELL];
@@ -11,8 +12,7 @@ export const NO_SELECTIONS: Selection[] = [];
 export const NO_CLICKABLES: Clickable[] = [];
 export const NO_STYLE = {};
 
-export const MAX_SEARCHABLE_INDEX = 65536;
-export const MAX_XY: XY = [MAX_SEARCHABLE_INDEX, MAX_SEARCHABLE_INDEX];
+export const MAX_SEARCHABLE_INDEX = 100000;
 
 export const COLORS = {
     selectionBorder: '#1a66ff',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import Sheet from './sheet';
 
+export { useClipboardTable } from './clipboard';
 export * from './sheet';
 export * from './types';
 

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,0 +1,192 @@
+import { RefObject, KeyboardEvent, useLayoutEffect } from 'react';
+
+import { ARROW_KEYS, MAX_SEARCHABLE_INDEX, ORIGIN, NEG_NEG } from './constants';
+
+import { findInDisplayData } from './props';
+
+import { CellContentType, CellPropertyFunction, CellPropertyStyledFunction, Change, Rectangle, XY } from './types';
+
+import {
+    normalizeSelection,
+    isRowSelection,
+    isColumnSelection,
+    isEmptySelection,
+    getDirectionStep,
+    maxXY,
+    addXY,
+} from './coordinate';
+
+export const useKeyboard = (
+    arrowKeyCommitMode: boolean,
+    overlayRef: RefObject<HTMLDivElement>,
+    cellReadOnly: CellPropertyFunction<boolean | null>,
+    displayData: CellPropertyStyledFunction<CellContentType>,
+    editCell: XY,
+    editMode: boolean,
+    focused: boolean,
+    rawSelection: Rectangle,
+    selection: Rectangle,
+
+    onEdit?: (cell: XY, arrowKeyCommitMode?: boolean) => void,
+    onCommit?: () => void,
+    onCancel?: () => void,
+    onSelectionChange?: (selection: Rectangle, scrollTo?: boolean, toHead?: boolean) => void,
+    onFocusChange?: (focus: boolean) => void,
+    onClipboardCopy?: (cut: boolean) => void,
+    onChange?: (changes: Change[]) => void
+) => {
+    const onInputKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            onCancel?.();
+            return;
+        }
+
+        const direction =
+            e.key === 'Enter' ? 'down' : e.key === 'Tab' ? 'right' : arrowKeyCommitMode ? ARROW_KEYS[e.key] : null;
+
+        if (direction) {
+            e.preventDefault();
+            const step = getDirectionStep(direction);
+            const head = maxXY(addXY(editCell, step), ORIGIN);
+            onCommit?.();
+            onSelectionChange?.([head, head]);
+        }
+    };
+
+    const onGridKeyDown = (e: KeyboardEvent) => {
+        if (editMode && arrowKeyCommitMode && e.key in ARROW_KEYS) {
+            onCommit?.();
+            return;
+        }
+
+        if ((e.metaKey || e.ctrlKey) && String.fromCharCode(e.which).toLowerCase() === 'v') {
+            return;
+        }
+
+        // copy
+        if ((e.metaKey || e.ctrlKey) && String.fromCharCode(e.which).toLowerCase() === 'c') {
+            onClipboardCopy?.(false);
+            return;
+        }
+        // cut
+        if ((e.metaKey || e.ctrlKey) && String.fromCharCode(e.which).toLowerCase() === 'x') {
+            onClipboardCopy?.(true);
+            return;
+        }
+
+        if (e.key === 'Backspace' || e.key === 'Delete') {
+            let [[x1, y1], [x2, y2]] = normalizeSelection(selection);
+            if (isRowSelection(selection)) {
+                x1 = 0;
+                x2 = MAX_SEARCHABLE_INDEX;
+            }
+            if (isColumnSelection(selection)) {
+                y1 = 0;
+                y2 = MAX_SEARCHABLE_INDEX;
+            }
+
+            const changes: Change[] = [];
+            for (let y = y1; y <= y2; y++) {
+                for (let x = x1; x <= x2; x++) {
+                    if (!cellReadOnly(x, y)) {
+                        changes.push({ x: x, y: y, value: null });
+                    }
+                }
+            }
+
+            onChange?.(changes);
+            return;
+        }
+
+        // nothing selected
+        if (isEmptySelection(selection)) {
+            return;
+        }
+
+        if (
+            (e.keyCode >= 48 && e.keyCode <= 57) ||
+            (e.keyCode >= 96 && e.keyCode <= 105) ||
+            (e.keyCode >= 65 && e.keyCode <= 90) ||
+            e.key === 'Enter' ||
+            e.key === '-' ||
+            e.key === '.' ||
+            e.key === ','
+        ) {
+            const [cell] = selection;
+            const [cellX, cellY] = cell;
+            if (cellReadOnly(cellX, cellY)) {
+                return;
+            }
+
+            onEdit?.(cell, e.key !== 'Enter');
+            return;
+        }
+
+        e.preventDefault();
+
+        if (e.key in ARROW_KEYS) {
+            let [anchor, head] = rawSelection;
+
+            const direction = ARROW_KEYS[e.key];
+            const step = getDirectionStep(direction);
+            const shift = e.shiftKey;
+
+            if (e.metaKey || e.ctrlKey) {
+                head = findInDisplayData(displayData, head, direction);
+            } else {
+                // Allow stepping into row/column headers with shift
+                const limit: XY = shift
+                    ? isRowSelection(selection)
+                        ? [-1, 0]
+                        : isColumnSelection(selection)
+                        ? [0, -1]
+                        : NEG_NEG
+                    : ORIGIN;
+                head = maxXY(addXY(head, step), limit);
+            }
+
+            if (!shift) {
+                anchor = head;
+            }
+
+            onSelectionChange?.([anchor, head], true, true);
+            return;
+        }
+    };
+
+    const onGridFocus = () => {
+        onFocusChange?.(true);
+    };
+
+    const onGridBlur = () => {
+        onFocusChange?.(false);
+    };
+
+    // Focus canvas for keyboard
+    useLayoutEffect(() => {
+        const { current: overlay } = overlayRef;
+        if (!overlay) {
+            return;
+        }
+        if (editMode || !focused) {
+            return;
+        }
+        if (document.activeElement === overlay) {
+            return;
+        }
+
+        const activeTagName = (document as any).activeElement.tagName.toLowerCase();
+        if (
+            !(
+                (activeTagName === 'div' && (document as any).activeElement.contentEditable === 'true') ||
+                activeTagName === 'input' ||
+                activeTagName === 'textarea' ||
+                activeTagName === 'select'
+            )
+        ) {
+            overlay.focus({ preventScroll: true });
+        }
+    }, [editMode, focused]);
+
+    return { onInputKeyDown, onGridFocus, onGridBlur, onGridKeyDown };
+};

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -76,8 +76,8 @@ export const useMouse = (
     onChange?: (changes: Change[]) => void,
     onColumnOrderChange?: (indices: number[], order: number) => void,
     onRowOrderChange?: (indices: number[], order: number) => void,
-    onCellWidthChange?: (indices: number[], value: number) => void,
-    onCellHeightChange?: (indices: number[], value: number) => void,
+    onCellWidthChange?: (indices: number[], values: number[]) => void,
+    onCellHeightChange?: (indices: number[], values: number[]) => void,
     onRightClick?: (e: SheetMouseEvent) => void,
 
     dontCommitEditOnSelectionChange?: boolean,
@@ -739,7 +739,10 @@ export const useMouse = (
                         SIZES.minimumWidth * indices.length
                     );
                     onInvalidateColumn?.(indices[0] - 1);
-                    onCellWidthChange(indices, newWidth / indices.length);
+                    onCellWidthChange(
+                        indices,
+                        indices.map((_) => newWidth / indices.length)
+                    );
                 }
                 return;
             }
@@ -753,7 +756,10 @@ export const useMouse = (
                         SIZES.minimumHeight * indices.length
                     );
                     onInvalidateRow?.(indices[0] - 1);
-                    onCellHeightChange(indices, newHeight / indices.length);
+                    onCellHeightChange(
+                        indices,
+                        indices.map((_) => newHeight / indices.length)
+                    );
                 }
                 return;
             }
@@ -915,8 +921,11 @@ export const useMouse = (
 
                 for (const column of autosized) {
                     onInvalidateColumn?.(column - 1);
-                    onCellWidthChange([column], getAutoSizeWidth(column));
                 }
+                onCellWidthChange(
+                    autosized,
+                    autosized.map((column) => getAutoSizeWidth(column))
+                );
                 if (autosized.length) return;
             }
 

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -68,6 +68,7 @@ export const useMouse = (
     onDragOffsetChange?: (dragOffset: XY | null) => void,
     onDropTargetChange?: (selection: Rectangle | null) => void,
     onSelectionChange?: (selection: Rectangle, scrollTo?: boolean, toHead?: boolean) => void,
+    onFocusChange?: (focus: boolean) => void,
 
     onInvalidateColumn?: (column: number) => void,
     onInvalidateRow?: (row: number) => void,
@@ -196,6 +197,8 @@ export const useMouse = (
                     knobPosition,
                 },
             } = ref;
+
+            onFocusChange?.(true);
 
             if (e.button !== 0) return;
 
@@ -497,6 +500,8 @@ export const useMouse = (
                     cellLayout: { pixelToColumn, pixelToRow, getIndentX, getIndentY },
                 },
             } = ref;
+
+            onFocusChange?.(true);
 
             if (knobArea && draggingKnob) {
                 const changes = parseKnobOperation(knobArea, selection, sourceData, editData, cellReadOnly);

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -118,8 +118,8 @@ export type SheetProps = {
     onChange?: (changes: Array<Change>) => void;
     onColumnOrderChange?: (indices: number[], order: number) => void;
     onRowOrderChange?: (indices: number[], order: number) => void;
-    onCellWidthChange?: (indices: number[], value: number) => void;
-    onCellHeightChange?: (indices: number[], value: number) => void;
+    onCellWidthChange?: (indices: number[], values: number[]) => void;
+    onCellHeightChange?: (indices: number[], values: number[]) => void;
     onScrollChange?: (visibleRows: number[], visibleColumns: number[]) => void;
 
     onCopy?: (selection: Rectangle, cells: string[][]) => ClipboardPayload<any> | null | undefined;

--- a/src/style.ts
+++ b/src/style.ts
@@ -17,13 +17,6 @@ export const resolveSheetStyle = (sheetStyle?: SheetStyle): InternalSheetStyle =
     };
 };
 
-export const resolveCellStyle = (optionalStyle: Style, defaultStyle: Required<Style>): Required<Style> => {
-    return {
-        ...defaultStyle,
-        ...optionalStyle,
-    };
-};
-
 export const applyAlignment = (
     start: number,
     cellSize: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,17 @@ import { MouseEvent, PointerEvent, CSSProperties } from 'react';
 
 export type PropTypes = string | number | boolean | Style | CellContentType;
 
+export type CellPropertyStyledFunction<T extends PropTypes> = (x: number, y: number, style: Required<Style>) => T;
+export type RowOrColumnPropertyStyledFunction<T extends PropTypes> = (
+    rowOrColIndex: number,
+    style: Required<Style>
+) => T;
+
 export type CellPropertyFunction<T extends PropTypes> = (x: number, y: number) => T;
 export type RowOrColumnPropertyFunction<T extends PropTypes> = (rowOrColIndex: number) => T;
+
+export type CellPropertyStyled<T extends PropTypes> = T | T[][] | CellPropertyStyledFunction<T>;
+export type RowOrColumnPropertyStyled<T extends PropTypes> = T | T[] | RowOrColumnPropertyStyledFunction<T>;
 
 export type CellProperty<T extends PropTypes> = T | T[][] | CellPropertyFunction<T>;
 export type RowOrColumnProperty<T extends PropTypes> = T | T[] | RowOrColumnPropertyFunction<T>;
@@ -99,6 +108,17 @@ export type Resizable = {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+// Clipboard
+////////////////////////////////////////////////////////////////////////////////
+
+export type ClipboardPayload<T> = {
+    cut: boolean;
+    data: T;
+    origin: string;
+    version: number;
+};
+
+////////////////////////////////////////////////////////////////////////////////
 // Changes
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -107,11 +127,6 @@ export type Change = {
     y: number;
     value: string | number | null;
     source?: { x: number; y: number };
-};
-
-export type ParsedChange = {
-    selection: Rectangle;
-    changes: Change[];
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
clipboard
- replace invisible textarea with clipboard api + onpaste event
- handle sheet focus explicitly

improvements
- add shift-arrow op for selecting whole rows or columns
- pass cell `Style` to cellContent/Header functions so icons can match color

fixes
- allow cmd-arrow to go outside 64k... skip 100k rows at a time max
- fix row resizing in examples, remove unused example code
- change column/row handler api to do multiple columns in one transaction