### PR TITLE
flex / autosize fixes

### DIFF
--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -518,8 +518,8 @@ export const useMouse = (
                 const [x, y] = xy;
                 const [[minX, minY], [maxX, maxY]] = normalizeSelection(selection);
 
-                const cellX = pixelToColumn(x, 0.5);
-                const cellY = pixelToRow(y, 0.5);
+                const cellX = Math.max(0, pixelToColumn(x, 0.5));
+                const cellY = Math.max(0, pixelToRow(y, 0.5));
 
                 if (columnDrag) {
                     const { indices } = columnDrag;

--- a/src/render.ts
+++ b/src/render.ts
@@ -447,8 +447,8 @@ export const renderCell = (
         const renderedAbsolute = resolveCellAbsoluteLayout(cellContent, innerX, innerY, innerWidth, innerHeight);
         const rendered = [...renderedFlex, ...renderedAbsolute];
 
-        clipToBox(context, innerX, innerY, innerWidth, innerHeight, () => {
-            for (const render of rendered) {
+        clipToBox(context, xCoord, yCoord, cellWidth, cellHeight, () => {
+            for (const [i, render] of rendered.entries()) {
                 const { box, item } = render;
 
                 const [[left, top], [right, bottom]] = box;
@@ -462,7 +462,11 @@ export const renderCell = (
                     context.strokeRect(left + 0.5, top + 0.5, width - 0.5, height - 0.5);
                 }
 
-                clipToBox(context, left, top, width, height, () => {
+                const clipLeft = i > 0 ? left : xCoord;
+                const clipRight = i < rendered.length ? right : yCoord + cellWidth;
+                const clipWidth = clipRight - clipLeft;
+
+                clipToBox(context, clipLeft, yCoord, clipWidth, cellHeight, () => {
                     if (item.display === 'inline') {
                         const { text } = item;
                         if (text != null) {

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -367,20 +367,24 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
     const getAutoSizeWidth = useAutoSizeColumn(
         visibleCells.rows,
         displayData,
+        cellLayout,
         cellStyle,
         columnHeaders,
         columnHeaderStyle,
         canvasWidth,
+        freezeColumns,
     );
 
     const getAutoSizeHeight = useAutoSizeRow(
         visibleCells.columns,
         displayData,
+        cellLayout,
         cellStyle,
         columnHeaders,
         columnHeaderStyle,
         cellWidth,
         canvasHeight,
+        freezeRows,
     );
 
     const { mouseHandlers, knobPosition } = useMouse(
@@ -534,6 +538,9 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
     let editTextAlign: 'right' | 'left' | 'center' = 'right';
     let editTextLineHeight = '';
     let editTextMargin = '';
+    let editTextFontSize = DEFAULT_CELL_STYLE.fontSize;
+    let editTextFontFamily = DEFAULT_CELL_STYLE.fontFamily;
+    let editTextFontWeight = DEFAULT_CELL_STYLE.fontWeight;
     if (editMode) {
         const style = { ...DEFAULT_CELL_STYLE, ...cellStyle(...editCell) };
         editTextPosition = cellToPixel(editCell);
@@ -542,6 +549,9 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
         editTextHeight = cellHeight(editCellY) - 3;
         editTextAlign = style.textAlign;
         editTextLineHeight = `${style.lineHeight}px`;
+        editTextFontSize = style.fontSize;
+        editTextFontFamily = style.fontFamily;
+        editTextFontWeight = style.fontWeight;
 
         // Deduct border + apply high-dpi nudge to line up with render
         const yNudge = getDpiNudge();
@@ -571,8 +581,9 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
             textAlign: editTextAlign,
             lineHeight: editTextLineHeight,
             color: 'black',
-            fontSize: DEFAULT_CELL_STYLE.fontSize,
-            fontFamily: 'sans-serif',
+            fontSize: editTextFontSize,
+            fontFamily: editTextFontFamily,
+            fontWeight: editTextFontWeight,
             resize: 'none',
         } as InputStyle,
     };


### PR DESCRIPTION
- better autosizing for rows w/ flexing indent
- adopt cell font style for input widget
- more generous clipping for rich cells so it goes edge-to-edge
- fix bug when dragging row/column beyond top/left of sheet