### PR TITLE
Improved rich editing, improved clipboard table

### DIFF
--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -47,7 +47,7 @@ export const useMouse = (
     knobArea: Rectangle | null,
     editMode: boolean,
     editData: CellPropertyFunction<string>,
-    sourceData: CellPropertyFunction<string | number | null>,
+    sourceData: CellPropertyFunction<object | string | number | null>,
     cellReadOnly: CellPropertyFunction<boolean | null>,
 
     canSizeColumn: RowOrColumnPropertyFunction<boolean | null>,
@@ -513,7 +513,7 @@ export const useMouse = (
             onFocusChange?.(true);
 
             if (knobArea && draggingKnob) {
-                const changes = parseKnobOperation(knobArea, selection, sourceData, editData, cellReadOnly);
+                const changes = parseKnobOperation(knobArea, selection, editData, sourceData, cellReadOnly);
 
                 onChange?.(changes);
                 onSelectionChange?.(knobArea, true, true);
@@ -1087,8 +1087,8 @@ export const useMouse = (
 const parseKnobOperation = (
     knobArea: Rectangle,
     selection: Rectangle,
-    sourceData: CellPropertyFunction<string | number | null>,
     editData: CellPropertyFunction<string>,
+    sourceData: CellPropertyFunction<object | string | number | null>,
     cellReadOnly: CellPropertyFunction<boolean | null>,
 ): Change[] => {
     const [[kx1, ky1], [kx2, ky2]] = normalizeSelection(knobArea);
@@ -1118,9 +1118,10 @@ const parseKnobOperation = (
         let srcY = sy1;
         for (let y = fy1; y <= fy2; y++) {
             for (let x = fx1; x <= fx2; x++) {
-                const value = sourceData(x, srcY);
+                const value = editData(x, srcY);
+                const data = sourceData(x, srcY);
                 if (!cellReadOnly(x, y)) {
-                    changes.push({ x: x, y: y, value: value, source: { x: x, y: srcY } });
+                    changes.push({ x: x, y: y, value, data, source: { x: x, y: srcY } });
                 }
             }
             srcY = srcY + 1;
@@ -1143,9 +1144,10 @@ const parseKnobOperation = (
         let srcX = sx1;
         for (let x = fx1; x <= fx2; x++) {
             for (let y = fy1; y <= fy2; y++) {
-                const value = sourceData(srcX, y);
+                const value = editData(srcX, y);
+                const data = sourceData(srcX, y);
                 if (!cellReadOnly(x, y)) {
-                    changes.push({ x: x, y: y, value: value, source: { x: srcX, y: y } });
+                    changes.push({ x: x, y: y, value, data, source: { x: srcX, y: y } });
                 }
             }
             srcX = srcX + 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,11 +165,25 @@ export type Resizable = {
 // Clipboard
 ////////////////////////////////////////////////////////////////////////////////
 
+export type ClipboardRawTable<T extends ClipboardTableCells = ClipboardTableCells> = {
+    rows: string[][];
+    payload?: ClipboardPayload<T>;
+};
+
 export type ClipboardPayload<T> = {
-    cut: boolean;
-    data: T;
     origin: string;
-    version: number;
+    cut?: boolean;
+    data?: T;
+};
+
+export type ClipboardTable<T extends ClipboardTableCells = ClipboardTableCells> = {
+    rows: string[][];
+    cut?: boolean;
+    data?: T;
+};
+
+export type ClipboardTableCells = {
+    cells?: Record<string, Record<string, any>>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -180,6 +194,7 @@ export type Change = {
     x: number;
     y: number;
     value: string | number | null;
+    data?: object | string | number | null;
     source?: { x: number; y: number };
 };
 


### PR DESCRIPTION
**Problem**
- SH doesn't support `object` values. The custom `inputComponent` API is limited to `string`, so we have to use `JSON.stringify` to pass e.g. array values around.
- When copy/pasting, we also force values to become `string`. Custom clipboard payloads are supported, but the default behavior is very limited.

**Proposal**
There is already a split between `editData` (`string`) and `sourceData` (`string | number | null`), which we can extend to support `object`. This is reflected in the new `Change` type:

- `editData` = `value` is entered manually (or pasted as text)
- `sourceData` = `data` is provided programmatically

We prefer `data` if it's provided, otherwise try and parse `value`.

For custom `inputComponents`, it makes sense to always work with `sourceData`, so it can be tied directly to React components. However a user can still paste text, so custom `inputComponent` still have to support both `value` and `data`.

This also improves the clipboard API. The payload type for rich cells is standardized as being `sourceData`, and included in the default clipboard handler. This means we don't round-trip tags to strings anymore out-of-the-box instead of needing workarounds.

**Summary**
- support for rich data edits/changes (`object`) on `Change` and `inputComponent`
- make `inputComponent` work with `sourceData` (any) instead of `editData` (string)
- improved clipboard API, standardize rich cell payload, centralize `origin` check
