### PR TITLE
fix: prevent picker data from leaking into next cell's edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,22 @@ build
 dist
 .rpt2_cache
 
+# caches
+.eslintcache
+*.tsbuildinfo
+
+# test/coverage output
+coverage
+
+# editor / IDE
+.vscode
+.idea
+*.swp
+*.swo
+
 # misc
 .DS_Store
+Thumbs.db
 .env
 .env.local
 .env.development.local

--- a/example/src/components/SheetBox.js
+++ b/example/src/components/SheetBox.js
@@ -836,7 +836,10 @@ export function SheetBoxCustomInput() {
             if (!newData[change.y]) {
                 newData[change.y] = [];
             }
-            newData[change.y][change.x] = change.value;
+            // Picker-driven changes carry the structured value in `data` and have `value: null`.
+            // Typed-text changes carry the typed string in `value` and have `data: null`.
+            // Prefer `data` when present, fall back to `value`.
+            newData[change.y][change.x] = change.data ?? change.value;
         }
         setData(newData);
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sheet-happens",
-  "version": "0.0.56",
+  "version": "0.0.58",
   "description": "React Spreadsheet",
   "author": "Luka-M",
   "license": "MIT",

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -335,11 +335,16 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
         const editValue = editData(cellX, cellY) ?? '';
         const sourceValue = sourceData(cellX, cellY) ?? null;
 
+        // `editValue` and `sourceValue` are a pair representing one edit; both must be
+        // (re)set on each start, otherwise the unset slot keeps its value from the
+        // previous edit and gets emitted by `commitEditingCell` as if it belonged to
+        // this one.
         if (hasData) {
             setEditValue(null);
             setSourceValue(sourceValue);
         } else {
             setEditValue(editValue);
+            setSourceValue(null);
         }
 
         setEditCell(editCell);

--- a/src/sheet.tsx
+++ b/src/sheet.tsx
@@ -330,7 +330,7 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
             return;
         }
 
-        const hasData = !!props.inputComponent?.(cellX, cellY, { ...inputProps, onChange: () => {} }, () => {});
+        const hasCustomComponent = !!props.inputComponent?.(cellX, cellY, { ...inputProps, onChange: () => {} }, () => {});
 
         const editValue = editData(cellX, cellY) ?? '';
         const sourceValue = sourceData(cellX, cellY) ?? null;
@@ -339,7 +339,7 @@ const Sheet = forwardRef<SheetRef, SheetProps>((props, ref) => {
         // (re)set on each start, otherwise the unset slot keeps its value from the
         // previous edit and gets emitted by `commitEditingCell` as if it belonged to
         // this one.
-        if (hasData) {
+        if (hasCustomComponent) {
             setEditValue(null);
             setSourceValue(sourceValue);
         } else {


### PR DESCRIPTION
## Summary
- `editValue` and `sourceValue` are a pair representing one edit, but only the `hasData` branch of `startEditingCell` was setting both. For cells without a custom `inputComponent`, the textarea path only updated `editValue`, leaving `sourceValue` holding state from a previous edit.
- `commitEditingCell` then emitted that stale `sourceValue` as `data` for an unrelated typed-text commit, letting a previous picker's id flow into the next cell's `Change`.

## Repro
1. Edit a cell that uses a custom `inputComponent` (e.g. a dropdown picker). Pick a value with id N. The picker's commit emits `{value: null, data: N}`.
2. Without reloading, click into a different cell that has no `inputComponent` (a plain textarea — number/percentage/text). Type any value and press Enter.
3. The emitted `Change` is `{value: typedString, data: N}` — the previous picker's id leaks in as `data`.

Consumers that prefer `data` over `value` (typical for paste/picker-aware handlers) then write the wrong value into the cell. In our app, this surfaced as percentage cells receiving raw member ids and rendering as `id × 100 %`.

## Fix
Reset `sourceValue` to `null` in the non-`hasData` branch of `startEditingCell`. The textarea path can only produce a typed string, so `null` is the honest pair value: "user typed this; no structured data accompanies it."

## Test plan
- [x] `yarn test:unit` passes.
- [x] `yarn test:build` passes.
- [x] Verified locally against a downstream consumer (the original repro is gone — typing into a numeric cell after a dropdown pick stores the typed value, not the picked id).